### PR TITLE
Update raspiBackup.sh

### DIFF
--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -7301,7 +7301,7 @@ function doitRestore() {
 		exitError $RC_MISSING_FILES
 	fi
 
-	if mount | grep -r "^$RESTORE_DEVICE"; then
+	if mount | grep "^$RESTORE_DEVICE"; then
 		writeToConsole $MSG_LEVEL_MINIMAL $MSG_RESTORE_PARTITION_MOUNTED "$RESTORE_DEVICE"
 		exitError $RC_RESTORE_IMPOSSIBLE
 	fi


### PR DESCRIPTION
Remove -r from mount | grep -r ...

As per https://unix.stackexchange.com/a/551836 '-r' without a filepath defaults to the working directory. In my case, restoring using a well-used raspberry, this was grepping my home directory which took a very long time and discovered the searched for strings in my personal files, e.g. 
Documents/4.info/backup/vpn/2021-07-06-13-img/mmcblk0-pt.sf:/dev/mmcblk0p1 : start=        8192, size=      524288, type=c
Documents/4.info/backup/vpn/2021-07-06-13-img/mmcblk0-pt.sf:/dev/mmcblk0p2 : start=      532480, size=    61988864, type=83

...which the gave the error that these devices were not unmounted. Removing '-r' solves this issue.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve?

**Explain how the PR was tested. If possible include a test script in your PR**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
