### PR TITLE
fixed a bug in raspiBackupRestoreHelper.sh.

### DIFF
--- a/helper/raspiBackupRestoreHelper.sh
+++ b/helper/raspiBackupRestoreHelper.sh
@@ -2,11 +2,18 @@
 
 ##########################################################################################################################################
 #
-# Auxiliary script for easy restore of a backup created with raspiBackup on Raspberry Pi OS.
-# Possibe Options:
-# --load     (automatic selection of the last backup)
-# --select   (any backup can be selected from a list)
-# Without Options   (This is the same process as with options except that at startup it asks whether the last backup should be restored.)
+# Auxiliary - script for easy, dialog guided creating or restoring of a backup with   "framps raspiBackup"
+# Possible options
+# --backup (simple dialog guided creation of a backup)
+# --last (creation of a restore with selection of the target drive)
+# --select (the backup to restore can be selected from a list of available backups)
+#
+# Without option (The program asks whether a backup should be created or a backup should be restored.
+# All options are asked in the program by dialog).
+#
+# Selectable languages "German" and "English"
+#
+# Requirement  Installing of "framps raspiBackup"
 #
 ##########################################################################################################################################
 #

--- a/helper/raspiBackupRestoreHelper.sh
+++ b/helper/raspiBackupRestoreHelper.sh
@@ -67,7 +67,8 @@ function backup(){
 			backup_add_part_and_comment
 
 		else
-			backup_add_comment
+			ignore=ignoreAdditionalPartitions
+			backup_add_comment "$ignore"
 
 			fi
 
@@ -91,7 +92,7 @@ function backup_add_part_and_comment(){
 		read Quest_comment_text
 		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" -P -T "1 2 $partitions"
 	else
-		/usr/local/bin/raspiBackup.sh -P -T "1 1 $partitions"
+		/usr/local/bin/raspiBackup.sh -P -T "1 2 $partitions"
 	fi
 }
 
@@ -106,9 +107,9 @@ function backup_add_comment(){
 		echo -e " $Quest_comment_text \n"
 		echo -e " -----------------------------------------------------------------------$normal \n"
 		read Quest_comment_text
-		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text"
+		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" --"$1"
 	else
-		/usr/local/bin/raspiBackup.sh
+		/usr/local/bin/raspiBackup.sh --"$1"
 	fi
 }
 

--- a/helper/raspiBackupRestoreHelper.sh
+++ b/helper/raspiBackupRestoreHelper.sh
@@ -64,18 +64,52 @@ function backup(){
 			echo -e " -----------------------------------------------------------------$normal \n"
 			read partitions
 			echo ""
-			/usr/local/bin/raspiBackup.sh -P -T "1 2 $partitions"
+			backup_add_part_and_comment
 
 		else
-			/usr/local/bin/raspiBackup.sh --ignoreAdditionalPartitions
+			backup_add_comment
 
 			fi
 
 	else
-		/usr/local/bin/raspiBackup.sh
+		backup_add_comment
 
 	fi
 		exit 0
+}
+
+function backup_add_part_and_comment(){
+		echo -e "$yellow ----------------------------------------------------------------------- \n"
+		echo -e " $Quest_comment \n"
+		echo -e " -----------------------------------------------------------------------$normal \n"
+		read Quest_comment
+
+	if [[ ${Quest_comment,,} =~ [yj] ]]; then
+		echo -e "$yellow ----------------------------------------------------------------------- \n"
+		echo -e " $Quest_comment_text \n"
+		echo -e " -----------------------------------------------------------------------$normal \n"
+		read Quest_comment_text
+		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" -P -T "1 2 $partitions"
+	else
+		/usr/local/bin/raspiBackup.sh -P -T "1 1 $partitions"
+	fi
+}
+
+function backup_add_comment(){
+		echo -e "$yellow ----------------------------------------------------------------------- \n"
+		echo -e " $Quest_comment \n"
+		echo -e " -----------------------------------------------------------------------$normal \n"
+		read Quest_comment
+
+	if [[ ${Quest_comment,,} =~ [yj] ]]; then
+		echo -e "$yellow ----------------------------------------------------------------------- \n"
+		echo -e " $Quest_comment_text \n"
+		echo -e " -----------------------------------------------------------------------$normal \n"
+		read Quest_comment_text
+		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text"
+	else
+		/usr/local/bin/raspiBackup.sh
+	fi
 }
 
 function execution(){
@@ -205,6 +239,8 @@ function language(){
 		Quest_backup_more_than_2="Sollen mehr als die 2 Standardpartitionen gesichert werden?   j/N"
 		Quest_additional_partitions="Bitte die Partitionsnummer(n) eingeben, die zusaetzlich \n  zu den Standardpartitionen gesichert werde sollen. \n  Falls mehrere, dann getrennt durch Leerzeichen.  \n  Beispiel:  3 4 5 "
 		Warn_only_drive="Bitte ein gueltiges Laufwerk eingeben"
+		Quest_comment="Soll ein Kommentar am Ende des Backup-Verzeichnisses eingefügt werden? \n Dieses Backup wird dann nicht automatisch recycled. \n j/N \n"
+		Quest_comment_text="Bitte gebe den Kommentar ein \n"
 
 	elif (( $lang == 2 )); then
 		Quest_last_backup="Should the last backup be restored? y/N "
@@ -223,7 +259,8 @@ function language(){
 		Quest_backup_more_than_2="Should more than the 2 standard partitions be backed up   y/N?"
 		Quest_additional_partitions="Please enter the partition number(s) that should be backed up \n  in addition to the default partitions. \n  If more than one, separate them with spaces. \n  Example:   3 4 5 "
 		Warn_only_drive="Please only enter a valid Drive"
-
+		Quest_comment="Should a comment be inserted at the end of the backup directory? \n This backup will then not be recycled automatically. \n y/N \n"
+		Quest_comment_text="Please enter the comment \n"
 	else
 		echo -e "$red False input. Please enter only 1 or 2"
 		echo -e " Falsche Eingabe. Bitte nur 1 oder 2 eingeben $normal"


### PR DESCRIPTION
If there were more than two system partitions and only the first two partitions were to be backed up, the option
"--ignnoreAdditionalPartitions" was not appended.
