### PR TITLE
fixed a bug in raspiBackupRestoreHelper

### DIFF
--- a/helper/raspiBackupRestoreHelper.sh
+++ b/helper/raspiBackupRestoreHelper.sh
@@ -67,7 +67,7 @@ function backup(){
 			backup_add_part_and_comment
 
 		else
-			ignore=ignoreAdditionalPartitions
+			ignore=--ignoreAdditionalPartitions
 			backup_add_comment "$ignore"
 
 			fi
@@ -107,9 +107,9 @@ function backup_add_comment(){
 		echo -e " $Quest_comment_text \n"
 		echo -e " -----------------------------------------------------------------------$normal \n"
 		read Quest_comment_text
-		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" --"$1"
+		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" "$1"
 	else
-		/usr/local/bin/raspiBackup.sh --"$1"
+		/usr/local/bin/raspiBackup.sh "$1"
 	fi
 }
 

--- a/helper/raspiBackupRestoreHelper.sh
+++ b/helper/raspiBackupRestoreHelper.sh
@@ -67,7 +67,8 @@ function backup(){
 			backup_add_part_and_comment
 
 		else
-			backup_add_comment
+			ignore=ignoreAdditionalPartitions
+			backup_add_comment "$ignore"
 
 			fi
 
@@ -106,9 +107,9 @@ function backup_add_comment(){
 		echo -e " $Quest_comment_text \n"
 		echo -e " -----------------------------------------------------------------------$normal \n"
 		read Quest_comment_text
-		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text"
+		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" --"$1"
 	else
-		/usr/local/bin/raspiBackup.sh
+		/usr/local/bin/raspiBackup.sh --"$1"
 	fi
 }
 

--- a/helper/raspiBackupRestoreHelper.sh
+++ b/helper/raspiBackupRestoreHelper.sh
@@ -92,7 +92,7 @@ function backup_add_part_and_comment(){
 		read Quest_comment_text
 		/usr/local/bin/raspiBackup.sh -M "$Quest_comment_text" -P -T "1 2 $partitions"
 	else
-		/usr/local/bin/raspiBackup.sh -P -T "1 1 $partitions"
+		/usr/local/bin/raspiBackup.sh -P -T "1 2 $partitions"
 	fi
 }
 


### PR DESCRIPTION
If there are more than 2 system partitions and only the first two partitions should be backed up, the --ignoreAdditionalPartitions option was not passed.