### PR TITLE
Enhancement: User provided pre/post to gracfully stop and start docker containers

### DIFF
--- a/extensions_userprovided/README.md
+++ b/extensions_userprovided/README.md
@@ -12,6 +12,6 @@ Credits to [DesertRider](https://github.com/DesertRider/)
 
 ## raspiBackup_docker
 
-A pre and post script that stops all running docker-container gracefully and starts them again after backupp is finished.
+A pre and post script that stops all running docker-container gracefully and starts them again after backup is finished.
 
 Povided by [Springjunky](https://github.com/Springjunky)

--- a/extensions_userprovided/README.md
+++ b/extensions_userprovided/README.md
@@ -8,3 +8,10 @@ A pre script is used to signal to Healthcheck.io that raspiBackup is starting an
 Maybe the code could already be adapted for this point...
 
 Credits to [DesertRider](https://github.com/DesertRider/)
+
+
+## raspiBackup_docker
+
+A pre and post script that stops all running docker-container gracefully and starts them again after backupp is finished.
+
+Povide by [Springjunky](https://github.com/Springjunky)

--- a/extensions_userprovided/README.md
+++ b/extensions_userprovided/README.md
@@ -14,4 +14,4 @@ Credits to [DesertRider](https://github.com/DesertRider/)
 
 A pre and post script that stops all running docker-container gracefully and starts them again after backupp is finished.
 
-Povide by [Springjunky](https://github.com/Springjunky)
+Povided by [Springjunky](https://github.com/Springjunky)

--- a/extensions_userprovided/raspiBackup_docker_post.sh
+++ b/extensions_userprovided/raspiBackup_docker_post.sh
@@ -1,0 +1,56 @@
+#!/bin/bash
+#######################################################################################################################
+#
+# Sample plugin for raspiBackup.sh
+# called after a backup finished
+#
+# Function: starts all stopped docker container
+#
+# See http://www.linux-tips-and-tricks.de/raspiBackup for additional information
+#
+########################################################################################################################
+#
+#    Copyright (c) 2022 Springjunky (https://github.com/Springjunky)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.#
+#
+#######################################################################################################################
+
+GIT_DATE="$Date: 2022-05-12 21:36:43 +0200$"
+GIT_COMMIT="$Sha1: 993abe4$"
+
+# set any variables and prefix all names with ext_ and some unique prefix to use a different namespace than the script
+# list of docker container stored in ext_dockerContainer_pre
+
+MSG_EXT_DOCKER1="ext_docker_1"
+MSG_EN[$MSG_EXT_DOCKER1]="RBK2000I: Starting before stopped docker-container: %s "
+MSG_DE[$MSG_EXT_DOCKER1]="RBK2000I: Starte zuvor gestoppte Docker-Container: %s"
+
+MSG_EXT_DOCKER2="ext_docker_2"
+MSG_EN[$MSG_EXT_DOCKER2]="RBK2000I: Error with docker-container please check status: %s"
+MSG_DE[$MSG_EXT_DOCKER2]="RBK2000I: Fehler bei Docker-Container bitte Status prüfen: %s"
+
+
+# $MSG_LEVEL_MINIMAL will write message all the time
+# $MSG_LEVEL_DETAILED will write message only if -m 1 parameter was used
+if [[ -n "${ext_dockerContainer_pre}" ]]; then
+     writeToConsole  $MSG_LEVEL_MINIMAL $MSG_EXT_DOCKER1 "$ext_dockerContainer_pre"
+     for container_to_start in $ext_dockerContainer_pre ; do 
+       # the pre script checks, if docker was available at  /usr/bin/docker
+       /usr/bin/docker start $container_to_start 2>&1>/dev/null
+      if [[ $? -ne 0 ]] ; then
+        writeToConsole  $MSG_LEVEL_MINIMAL $MSG_EXT_DOCKER3 ${container_to_start}
+      fi
+     done
+fi

--- a/extensions_userprovided/raspiBackup_docker_post.sh
+++ b/extensions_userprovided/raspiBackup_docker_post.sh
@@ -38,8 +38,8 @@ MSG_EN[$MSG_EXT_DOCKER1]="RBK2000I: Starting before stopped docker-container: %s
 MSG_DE[$MSG_EXT_DOCKER1]="RBK2000I: Starte zuvor gestoppte Docker-Container: %s"
 
 MSG_EXT_DOCKER2="ext_docker_2"
-MSG_EN[$MSG_EXT_DOCKER2]="RBK2000I: Error with docker-container please check status: %s"
-MSG_DE[$MSG_EXT_DOCKER2]="RBK2000I: Fehler bei Docker-Container bitte Status prüfen: %s"
+MSG_EN[$MSG_EXT_DOCKER2]="RBK2001I: Error with docker-container please check status: %s"
+MSG_DE[$MSG_EXT_DOCKER2]="RBK2001I: Fehler bei Docker-Container bitte Status prüfen: %s"
 
 
 # $MSG_LEVEL_MINIMAL will write message all the time

--- a/extensions_userprovided/raspiBackup_docker_pre.sh
+++ b/extensions_userprovided/raspiBackup_docker_pre.sh
@@ -1,0 +1,64 @@
+#!/bin/bash
+#######################################################################################################################
+#
+# Docker plugin for raspiBackup.sh
+# called before a backup is started
+#
+# Function: Stops all running docker-container gracefull.
+#
+# See http://www.linux-tips-and-tricks.de/raspiBackup for additional information
+#
+#######################################################################################################################
+#
+#    Copyright (c) 2022 Springjunky (https://github.com/Springjunky)
+#
+#    This program is free software: you can redistribute it and/or modify
+#    it under the terms of the GNU General Public License as published by
+#    the Free Software Foundation, either version 3 of the License, or
+#    (at your option) any later version.
+#
+#    This program is distributed in the hope that it will be useful,
+#    but WITHOUT ANY WARRANTY; without even the implied warranty of
+#    MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#    GNU General Public License for more details.
+#
+#    You should have received a copy of the GNU General Public License
+#    along with this program.  If not, see <http://www.gnu.org/licenses/>.#
+#
+#######################################################################################################################
+
+GIT_DATE="$Date: 2022-05-12 21:36:43 +0200$"
+GIT_COMMIT="$Sha1: 993abe4$"
+
+MSG_EXT_DOCKER1="ext_docker_1"
+MSG_EN[$MSG_EXT_DOCKER1]="RBK2000I: Stopping Docker-Container: %s "
+MSG_DE[$MSG_EXT_DOCKER1]="RBK2000I: Beende Docker-Container: %s"
+
+
+# gets a list of all running Docker container in one line sperated with blanks
+function getRunningContainer () {
+  if [[ -x  "$(which docker)"  ]] ; then
+    local docker_bin=$(which docker)
+    local count_running_container=$($docker_bin container ls -q | wc -l)
+    if [[ $count_running_container -gt 0 ]] ; then
+     echo "$($docker_bin container ls --format '{{.Names}}'|tr '\n' ' ')"
+    else
+     echo ""
+    fi
+ fi 
+}
+
+# stops all given docker container
+function stopRunningContainer () { 
+  local running_container=$1	
+  if [[ -n "${running_container}" ]] ; then
+    writeToConsole  $MSG_LEVEL_MINIMAL $MSG_EXT_DOCKER1 "$running_container"
+    local docker_bin=$(which docker)
+    $docker_bin container stop $running_container 2>&1>/dev/null
+  fi
+}
+
+# ext_dockerContainer_pre is used in raspiBackup_docker_post.sh to start all 
+# stopped container
+ext_dockerContainer_pre="$(getRunningContainer)" 
+stopRunningContainer "$ext_dockerContainer_pre"


### PR DESCRIPTION
## Description

#### Pre-Script:
gets a list of all running containers and stops them

#### Post-Script:
start all the before stopped containers 

If /usr/bin/docker ist not available or no container ist running the script does nothing
