### PR TITLE
Enhance f2fs support

### DIFF
--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -7753,7 +7753,6 @@ function restorePartitionBasedPartition() { # restorefile
                         elif [[ $partitionFilesystem == "f2fs" ]]; then
                                 check4RequiredCommands f2fs
                                 if [[ -n $partitionLabel ]]; then
-                                        logItem "Creating f2fs partition with label '$partitionLabel'"
                                         cmd="mkfs.f2fs -f -l $partitionLabel "
                                 else
                                         cmd="mkfs.f2fs -f"
@@ -7787,8 +7786,7 @@ function restorePartitionBasedPartition() { # restorefile
 						;;
 					btrfs) cmd="btrfs filesystem label"
 						;;
-                                        f2fs) logItem "Creating dummy-command to not fail labeling f2fs partition"
-                                                cmd="echo 'Skipping f2fs label command, already done in mkfs.f2fs' #"
+                                        f2fs) cmd=": noop until f2fs 1.5 is available on Raspberries # <f2fs label command>"
                                                 ;;
 				esac
 

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -382,7 +382,7 @@ declare -A REQUIRED_COMMANDS_BTRFS=( \
 )
 
 declare -A REQUIRED_COMMANDS_F2FS=( \
-	["f2fslabel"]="f2fs-tools"
+	["f2fstat"]="f2fs-tools"
 )
 
 # possible script exit codes
@@ -7750,9 +7750,14 @@ function restorePartitionBasedPartition() { # restorefile
 			if [[ $partitionFilesystem == "btrfs" ]]; then
 				check4RequiredCommands btrfs
 				cmd="mkfs.btrfs -f"
-			elif [[ $partitionFilesystem == "f2fs" ]]; then
-				check4RequiredCommands f2fs
-				cmd="mkfs.f2fs -f"
+                        elif [[ $partitionFilesystem == "f2fs" ]]; then
+                                check4RequiredCommands f2fs
+                                if [[ -n $partitionLabel ]]; then
+                                        logItem "Creating f2fs partition with label '$partitionLabel'"
+                                        cmd="mkfs.f2fs -f -l $partitionLabel "
+                                else
+                                        cmd="mkfs.f2fs -f"
+                                fi
 			else
 				cmd="mkfs -t $fs"
 			fi
@@ -7782,8 +7787,9 @@ function restorePartitionBasedPartition() { # restorefile
 						;;
 					btrfs) cmd="btrfs filesystem label"
 						;;
-					f2fs) assertionFailed $LINENO "No labels supported for f2fslabel" # f2fslabel not availabel of Raspbian
-						;;
+                                        f2fs) logItem "Creating dummy-command to not fail labeling f2fs partition"
+                                                cmd="echo 'Skipping f2fs label command, already done in mkfs.f2fs' #"
+                                                ;;
 				esac
 
 				logItem "$cmd $mappedRestorePartition $partitionLabel"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -382,7 +382,7 @@ declare -A REQUIRED_COMMANDS_BTRFS=( \
 )
 
 declare -A REQUIRED_COMMANDS_F2FS=( \
-	["f2fs"]="f2fs-tools"
+	["f2fslabel"]="f2fs-tools"
 )
 
 # possible script exit codes
@@ -8749,18 +8749,18 @@ function check4RequiredCommands() { # btrfs | f2fs
 		for cmd in "${!REQUIRED_COMMANDS_BTRFS[@]}"; do
 			if ! hash $cmd 2>/dev/null; then
 				missing_commands="$cmd $missing_commands "
-				missing_packages="${REQUIRED_COMMANDS[$cmd]} $missing_packages "
+				missing_packages="${REQUIRED_COMMANDS_BTRFS[$cmd]} $missing_packages "
 			fi
 		done
-	elif [[ "$1" == "e2fs" ]]; then
+	elif [[ "$1" == "f2fs" ]]; then
 		for cmd in "${!REQUIRED_COMMANDS_F2FS[@]}"; do
 			if ! hash $cmd 2>/dev/null; then
 				missing_commands="$cmd $missing_commands "
-				missing_packages="${REQUIRED_COMMANDS[$cmd]} $missing_packages "
+				missing_packages="${REQUIRED_COMMANDS_F2FS[$cmd]} $missing_packages "
 			fi
 		done
 	else
-			assertionFailed $LINENO "Invalid arg"
+			assertionFailed $LINENO "Invalid arg: '$1'"
 	fi
 
 	if [[ -n "$missing_commands" ]]; then


### PR DESCRIPTION
This PR fixes basic backup and restore of f2fs partitions.

The functionality was tested with f2fs-tools version 1.14. 
Version 1.15 would allow for labeling similar to extX as it would provide a new 'f2fslabel' command, but many Raspberry Pi OSs currently are not yet on the required version (ie. Debian Bookworm).

So setting the label is done in the mkfs.f2fs stage and the labeling stage contains a workaround to not fail at an assertion there.

Basic backup and restore work on my side, booting should also work as long as the f2fs was created with default options. If manual options were used (eg. ext_attr) then the restore succeeds, but the image may not be bootable without manual intervention by fixing the /boot/cmdline.txt or /etc/fstab options. (See https://wiki.archlinux.org/title/F2FS#Remounting_impossible_with_some_options for details on how to perform those changes manually.)
But at least the file data itself becomes available again through the restore.

In case later the requirements on the f2fs-tools are raised to >=1.15 then following places can be simplified:
- REQUIRED_COMMANDS_F2FS should be changed to `f2fslabel` instead of `f2fstat`
- the if/else in the mkfs.f2fs section can be reduced to `cmd="mkfs.f2fs -f"` like it is for the other FSs
- the workaround in the labeling section can be reduced to `f2fs) cmd="f2fslabel"`