### PR TITLE
Include the OS release info in backup directory names

### DIFF
--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -3872,7 +3872,13 @@ function readConfigParameters() {
 
 function getOSRelease() {
 
-	test -e /etc/os-release && os_release_file='/etc/os-release' || test -e /usr/lib/os-release && os_release_file='/usr/lib/os-release' || os_release_file='/dev/null'
+	local os_release_file='/dev/null' # fallback
+	for file in /etc/os-release /usr/lib/os-release; do
+		if [[ -e $file ]]; then
+			os_release_file="$file"
+			break
+		fi
+	done
 
         # the prefix "osr_" prevents a lonely "local" with its output below when grep is unsuccessful
         unset osr_ID osr_VERSION_ID              # unset possible values used from global scope then
@@ -3882,7 +3888,7 @@ function getOSRelease() {
 
         os_release="${osr_ID}${osr_VERSION_ID}"  # e.g. debian12 or even debian"12"
         os_release="${os_release//\"/}"          # remove any double quotes
-        echo "${os_release:-unknown}"            # handle empty result
+        echo "${os_release:-unknownOS}"          # handle empty result
 }
 
 function setupEnvironment() {

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -4817,12 +4817,12 @@ function cleanup() { # trap
 				|| ! $SMART_RECYCLE \
 				)); then
 				applyBackupStrategy
-				reportOldBackups
 			fi
 		fi
 	fi
 
 	cleanupTempFiles
+	reportOldBackups
 
 	finalCommand "$rc"
 

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -7292,8 +7292,8 @@ function findNonpartitionBackupBootAndRootpartitionFiles() {
 	if [[ -f "$RESTOREFILE" || $BACKUPTYPE == $BACKUPTYPE_RSYNC ]]; then
 		ROOT_RESTOREFILE="$RESTOREFILE"
 	else
-		logItem "${RESTOREFILE}/${HOSTNAME_OSR}-*-backup*"
-		ROOT_RESTOREFILE="$(ls ${RESTOREFILE}/${HOSTNAME_OSR}-*-backup*)"
+		logItem "${RESTOREFILE}/${HOSTNAME}-*-backup*"
+		ROOT_RESTOREFILE="$(ls ${RESTOREFILE}/${HOSTNAME}-*-backup*)"
 		logItem "ROOT_RESTOREFILE: $ROOT_RESTOREFILE"
 		if [[ -z "$ROOT_RESTOREFILE" ]]; then
 			writeToConsole $MSG_LEVEL_MINIMAL $MSG_NO_ROOTBACKUPFILE_FOUND $BACKUPTYPE
@@ -8008,6 +8008,7 @@ function doitRestore() {
 	logItem "Basedir: $BASE_DIR"
 	# Note: Handle old (without) and new (with OS release info) backup directory names
 	HOSTNAME=$(basename "$RESTOREFILE" | sed -r 's/(.*)(@[A-Za-z0-9]+)*-[A-Za-z]+-backup-[0-9]+-[0-9]+.*/\1/')
+	HOSTNAME=${HOSTNAME%@*}
 	logItem "Hostname: $HOSTNAME"
 	BACKUPTYPE=$(basename "$RESTOREFILE" | sed -r 's/.*-([A-Za-z]+)-backup-[0-9]+-[0-9]+.*/\1/')
 	logItem "Backuptype: $BACKUPTYPE"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -1831,6 +1831,14 @@ MSG_DE[$MSG_NO_FILEATTRIBUTE_RIGHTS]="RBK0266E: Es fehlt die Berechtigung um Lin
 MSG_FI[$MSG_NO_FILEATTRIBUTE_RIGHTS]="RBK0266E: Käyttöoikeudet tiedostoattribuuttien luomiseen puuttuvat kohteesta %s (Tiedostojärjestelmä: %s)."
 MSG_FR[$MSG_NO_FILEATTRIBUTE_RIGHTS]="RBK0266E: Droits d'accès manquants pour créer des attributs de fichier sur %s (système de fichiers : %s)."
 
+MSG_EXISTING_BACKUP=400
+MSG_EN[$MSG_EXISTING_BACKUP]="RBK0400I: Existing backup: %s"
+MSG_DE[$MSG_EXISTING_BACKUP]="RBK0400I: Existierendes Backup: %s"
+MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED=401
+MSG_EN[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup strategy would delete %s."
+MSG_DE[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup Strategie würde %s Backup löschen."
+MSG_FI[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Varmuuskopiointistrategia poistaisi kohteen %s."
+
 #
 # Non NLS messages
 #
@@ -6165,11 +6173,11 @@ function applyBackupStrategy() {
 				fi
 				tobeCheckedBackups=$(ls -d ${HOSTNAME_OSR}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_")
 				echo "$tobeCheckedBackups" | while read dir_to_check; do
-					[[ -n $dir_to_check ]] && echo "!!! Matching backup found: $BACKUPTARGET_ROOT/${dir_to_check}"
+					[[ -n $dir_to_check ]] && writeToConsole $MSG_LEVEL_MINIMAL $MSG_EXISTING_BACKUP  $BACKUPTARGET_ROOT/${dir_to_check}
 				done
 				tobeDeletedBackups=$(ls -d ${HOSTNAME_OSR}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_" | head -n -$fakeKeepBackups 2>>$LOG_FILE)
 				echo "$tobeDeletedBackups" | while read dir_to_delete; do
-					[[ -n $dir_to_delete ]] && writeToConsole $MSG_LEVEL_MINIMAL $MSG_SMART_RECYCLE_FILE_WOULD_BE_DELETED "$BACKUPTARGET_ROOT/${dir_to_delete}"
+					[[ -n $dir_to_delete ]] && writeToConsole $MSG_LEVEL_MINIMAL $MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED "$BACKUPTARGET_ROOT/${dir_to_delete}"
 				done
 				if ! popd &>>$LOG_FILE; then
 					assertionFailed $LINENO "pop failed"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -3872,23 +3872,22 @@ function readConfigParameters() {
 
 function getOSRelease() {
 
-	local os_release_file='/dev/null' # fallback
-	for file in /etc/os-release /usr/lib/os-release; do
-		if [[ -e $file ]]; then
-			os_release_file="$file"
-			break
-		fi
+	local os_release_file
+	local os_release
+
+	for os_release_file in /etc/os-release /usr/lib/os-release /dev/null ; do
+		[[ -e "$os_release_file" ]] && break
 	done
 
-        # the prefix "osr_" prevents a lonely "local" with its output below when grep is unsuccessful
-        unset osr_ID osr_VERSION_ID              # unset possible values used from global scope then
+	# the prefix "osr_" prevents a lonely "local" with its output below when grep is unsuccessful
+	unset osr_ID osr_VERSION_ID              # unset possible values used from global scope then
 
-        local osr_$(grep -E "^ID="         "$os_release_file")
-        local osr_$(grep -E "^VERSION_ID=" "$os_release_file")
+	local osr_$(grep -E "^ID="         "$os_release_file")
+	local osr_$(grep -E "^VERSION_ID=" "$os_release_file")
 
-        os_release="${osr_ID}${osr_VERSION_ID}"  # e.g. debian12 or even debian"12"
-        os_release="${os_release//\"/}"          # remove any double quotes
-        echo "${os_release:-unknownOS}"          # handle empty result
+	os_release="${osr_ID}${osr_VERSION_ID}"  # e.g. debian12 or even debian"12"
+	os_release="${os_release//\"/}"          # remove any double quotes
+	echo "${os_release:-unknownOS}"          # handle empty result
 }
 
 function setupEnvironment() {

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -6859,7 +6859,7 @@ function inspect4Backup() {
 		fi
 
 		logItem "bootMountpoint: $bootMountpoint, bootPartition: $bootPartition"
-		
+
 		logItem "Starting root discovery"
 
 		# find root partition
@@ -7257,8 +7257,8 @@ function doitBackup() {
 	fi
 
 	if (( $SYSTEMSTATUS )) && ! which lsof &>/dev/null; then
-		 writeToConsole $MSG_LEVEL_MINIMAL $MSG_MISSING_INSTALLED_FILE "lsof" "lsof"
-		 exitError $RC_MISSING_COMMANDS
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_MISSING_INSTALLED_FILE "lsof" "lsof"
+		exitError $RC_MISSING_COMMANDS
 	fi
 
 	writeToConsole $MSG_LEVEL_MINIMAL $MSG_USING_BACKUPPATH "$BACKUPPATH" "$(getFsType "$BACKUPPATH")"
@@ -7283,10 +7283,10 @@ function doitBackup() {
 	BACKUPPATH_PARAMETER="$BACKUPPATH"
 	BACKUPPATH="$BACKUPPATH/$HOSTNAME"
 	if [[ ! -d "$BACKUPPATH" ]]; then
-		 if ! mkdir -p "${BACKUPPATH}"; then
+		if ! mkdir -p "${BACKUPPATH}"; then
 			writeToConsole $MSG_LEVEL_MINIMAL $MSG_UNABLE_TO_CREATE_DIRECTORY "$BACKUPPATH"
 			exitError $RC_CREATE_ERROR
-		 fi
+		fi
 	fi
 
 	logCommand "ls -1 ${BACKUPPATH}"
@@ -8267,8 +8267,8 @@ function updateRestoreReminder() {
 
 		# initialize reminder state
 		if [[ ! -e "$reminder_file" ]]; then
-			 echo "$(date +%Y%m) 0" > "$reminder_file"
-			 return
+			echo "$(date +%Y%m) 0" > "$reminder_file"
+			return
 		fi
 
 		# retrieve reminder state
@@ -8276,7 +8276,7 @@ function updateRestoreReminder() {
 		now=$(date +%Y%m)
 		local rf
 		rf="$(<$reminder_file)"
-		if [[ -z "${rf}" ]]; then												# issue #316: reminder file exists but is empty
+		if [[ -z "${rf}" ]]; then				# issue #316: reminder file exists but is empty
 			echo "$(date +%Y%m) 0" > "$reminder_file"
 			return
 		fi
@@ -8952,7 +8952,7 @@ function usageEN() {
 	[ -z "$DEFAULT_STOPSERVICES" ] && DEFAULT_STOPSERVICES="no"
 	echo "-a \"{commands to execute after Backup}\" (default: $DEFAULT_STARTSERVICES)"
 	echo "-B Save bootpartition in tar file (Default: $DEFAULT_TAR_BOOT_PARTITION_ENABLED)"
- 	echo "-F Backup is simulated"
+	echo "-F Backup is simulated"
 	echo "-k {backupsToKeep} (default: $DEFAULT_KEEPBACKUPS)"
 	[ -z "$DEFAULT_STARTSERVICES" ] && DEFAULT_STARTSERVICES="no"
 	echo "-o \"{commands to execute before Backup}\" (default: $DEFAULT_STOPSERVICES)"
@@ -9003,7 +9003,7 @@ function usageDE() {
 	[ -z "$DEFAULT_STOPSERVICES" ] && DEFAULT_STOPSERVICES="keine"
 	echo "-a \"{Befehle die nach dem Backup ausgeführt werden}\" (Standard: $DEFAULT_STARTSERVICES)"
 	echo "-B Sicherung der Bootpartition als tar file (Standard: $DEFAULT_TAR_BOOT_PARTITION_ENABLED)"
-  	echo "-F Backup wird nur simuliert"
+	echo "-F Backup wird nur simuliert"
 	echo "-k {Anzahl Backups} (Standard: $DEFAULT_KEEPBACKUPS)"
 	[ -z "$DEFAULT_STARTSERVICES" ] && DEFAULT_STARTSERVICES="keine"
 	echo "-o \"{Befehle die vor dem Backup ausgeführt werden}\" (Standard: $DEFAULT_STOPSERVICES)"
@@ -9052,7 +9052,7 @@ function usageFI() {
 	[ -z "$DEFAULT_STOPSERVICES" ] && DEFAULT_STOPSERVICES="ei"
 	echo "-a \"{varmuuskopion jläkeen suoritettavat komennot}\" (oletus: $DEFAULT_STARTSERVICES)"
 	echo "-B Tee käynnistysosiosta kopio tar tiedostoon (oletus: $DEFAULT_TAR_BOOT_PARTITION_ENABLED)"
- 	echo "-F Varmuuskopioinnin simulointi"
+	echo "-F Varmuuskopioinnin simulointi"
 	echo "-k {säilytettävien varmuuskopioiden lkm} (oletus: $DEFAULT_KEEPBACKUPS)"
 	[ -z "$DEFAULT_STARTSERVICES" ] && DEFAULT_STARTSERVICES="ei"
 	echo "-o \"{ennen varmuuskopiointia suoritettavat komennot}\" (oletus: $DEFAULT_STOPSERVICES)"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -5593,6 +5593,8 @@ function updateUUID() {
 
 function backupRsync() { # partition number (for partition based backup)
 
+	# Note: Determining lastbackupDir now depends even more on the naming convention of the backups. See the "sort -t '-' -k 4" commands below!
+
 	local verbose partition target source excludeRoot cmd cmdParms excludeMeta
 
 	logEntry
@@ -5609,7 +5611,7 @@ function backupRsync() { # partition number (for partition based backup)
 		target="\"${BACKUPTARGET_DIR}\""
 		source="$TEMPORARY_MOUNTPOINT_ROOT/$partition"
 
-		lastBackupDir=$(find "$BACKUPTARGET_ROOT" -maxdepth 1 -type d -name "*-$BACKUPTYPE-*" ! -name $BACKUPFILE 2>>/dev/null | sort | tail -n 1)
+		lastBackupDir=$(find "$BACKUPTARGET_ROOT" -maxdepth 1 -type d -name "*-$BACKUPTYPE-*" ! -name $BACKUPFILE 2>>/dev/null | sort -t "-" -k 4 | tail -n 1)
 		excludeRoot="/$partition"
 
 	else
@@ -5617,7 +5619,7 @@ function backupRsync() { # partition number (for partition based backup)
 		source="/"
 
 		bootPartitionBackup
-		lastBackupDir=$(find "$BACKUPTARGET_ROOT" -maxdepth 1 -type d -name "${HOSTNAME_OSR}*-$BACKUPTYPE-*" ! -name $BACKUPFILE 2>>/dev/null | sort | tail -n 1)
+		lastBackupDir=$(find "$BACKUPTARGET_ROOT" -maxdepth 1 -type d -name "*-$BACKUPTYPE-*" ! -name $BACKUPFILE 2>>/dev/null | sort -t "-" -k 4 | tail -n 1)
 		excludeRoot=""
 		excludeMeta="--exclude=/$BACKUPFILES_PARTITION_DATE.img --exclude=/$BACKUPFILES_PARTITION_DATE.tmg --exclude=/$BACKUPFILES_PARTITION_DATE.sfdisk --exclude=/$BACKUPFILES_PARTITION_DATE.blkid --exclude=/$BACKUPFILES_PARTITION_DATE.fdisk --exclude=/$BACKUPFILES_PARTITION_DATE.parted --exclude=/$BACKUPFILES_PARTITION_DATE.mbr --exclude=/$MYNAME.log --exclude=/$MYNAME.msg"
 	fi
@@ -6076,6 +6078,8 @@ function restore() {
 
 function applyBackupStrategy() {
 
+	# Note: Determining the backups to be deleted now depends even more on the naming convention of the backups. See the "sort -t '-' -k 4" commands below!
+
 	logEntry "$BACKUP_TARGETDIR"
 
 	if (( $SMART_RECYCLE )); then
@@ -6092,11 +6096,11 @@ function applyBackupStrategy() {
 
 		logCommand "ls -d $BACKUPPATH/*"
 
-		local keptBackups="$(SR_listUniqueBackups $BACKUPTARGET_ROOT)"
+		local keptBackups="$(SR_listUniqueBackups $BACKUPTARGET_ROOT | sort -t '-' -k 4)"
 		local numKeptBackups="$(countLines "$keptBackups")"
 		logItem "Keptbackups $numKeptBackups: $keptBackups"
 
-		local tobeDeletedBackups="$(SR_listBackupsToDelete "$BACKUPTARGET_ROOT")"
+		local tobeDeletedBackups="$(SR_listBackupsToDelete "$BACKUPTARGET_ROOT" | sort -t '-' -k 4)"
 		local numTobeDeletedBackups="$(countLines "$tobeDeletedBackups")"
 		logItem "TobeDeletedBackups $numTobeDeletedBackups: $tobeDeletedBackups"
 
@@ -6141,7 +6145,7 @@ function applyBackupStrategy() {
 				if ! pushd "$BACKUPPATH" &>>$LOG_FILE; then
 					assertionFailed $LINENO "push to $BACKUPPATH failed"
 				fi
-				ls -d ${HOSTNAME_OSR}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_" | head -n -$keepBackups | xargs -I {} rm -rf "{}" &>>"$LOG_FILE";
+				ls -d ${HOSTNAME}*-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_" | sort -t "-" -k 4 | head -n -$keepBackups | xargs -I {} rm -rf "{}" &>>"$LOG_FILE";
 				if ! popd &>>$LOG_FILE; then
 					assertionFailed $LINENO "pop failed"
 				fi
@@ -8643,7 +8647,7 @@ function SR_listYearlyBackups() { # directory
 			# today is 20191117
 			# date +%Y -d "0 year ago" -> 2019
 			local d=$(date +%Y -d "${i} year ago")
-			ls -1 $1 | egrep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d[0-9]{2}[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earliest yearly backup
+			ls -1 $1 | egrep "\-${BACKUPTYPE}\-backup\-$d[0-9]{2}[0-9]{2}" | grep -Ev "_" | sort -ur -t "-" -k 4 | tail -n 1 # find earliest yearly backup
 		done
 	fi
 	logExit
@@ -8659,7 +8663,7 @@ function SR_listMonthlyBackups() { # directory
 			# today is 20191117
 			# date -d "$(date +%Y%m15) -0 month" +%Y%m -> 201911
 			local d=$(date -d "$(date +%Y%m15) -${i} month" +%Y%m) # get month
-			ls -1 $1 | egrep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earlies monthly backup
+			ls -1 $1 | egrep "\-${BACKUPTYPE}\-backup\-$d[0-9]{2}" | grep -Ev "_" | sort -ur -t "-" -k 4 | tail -n 1 # find earliest monthly backup
 		done
 	fi
 	logExit
@@ -8682,9 +8686,9 @@ function SR_listWeeklyBackups() { # directory
 			local mon=$(date +%Y%m%d -d "$last monday -${i} weeks") # calculate monday of week
 			local dl=""
 			for ((d=0;d<=6;d++)); do	# now build list of week days of week (mon-sun)
-				dl="${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$(date +%Y%m%d -d "$mon + $d day") $dl"
+				dl="\-${BACKUPTYPE}\-backup\-$(date +%Y%m%d -d "$mon + $d day") $dl"
 			done
-			ls -1 $1 | grep -e "$(echo -n $dl | sed "s/ /\\\|/g")" | grep -Ev "_" | sort -ur | tail -n 1 # use earliest backup of this week
+			ls -1 $1 | grep -e "$(echo -n $dl | sed "s/ /\\\|/g")" | grep -Ev "_" | sort -ur  -t "-" -k 4 | tail -n 1 # use earliest backup of this week
 		done
 	fi
 	logExit
@@ -8698,7 +8702,7 @@ function SR_listDailyBackups() { # directory
 			# today is 20191117
 			# date +%Y%m%d -d "-1 day" -> 20191116
 			local d=$(date +%Y%m%d -d "-${i} day") # get day
-			ls -1 $1 | grep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d" | grep -Ev "_" | sort -ur | head -n 1 # find most current backup of this day
+			ls -1 $1 | grep "\-${BACKUPTYPE}\-backup\-$d" | grep -Ev "_" | sort -ur -t "-" -k 4 | head -n 1 # find most current backup of this day
 		done
 	fi
 	logExit
@@ -8740,7 +8744,7 @@ function SR_listUniqueBackups() { #directory
 
 function SR_listBackupsToDelete() { # directory
 	logEntry $1
-	local r="$(ls -1 $1 | grep -v -e "$(echo -n $(SR_listUniqueBackups "$1") -e "_" | sed "s/ /\\\|/g")" | grep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-" )" # make sure to delete only backup type files
+	local r="$(ls -1 $1 | grep -v -e "$(echo -n $(SR_listUniqueBackups "$1") -e "_" | sed "s/ /\\\|/g")" | grep "\-${BACKUPTYPE}\-backup\-" )" # make sure to delete only backup type files
 	local rc="$(countLines "$r")"
 	logItem "$r"
 	echo "$r"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -6157,8 +6157,7 @@ function applyBackupStrategy() {
 				if ! pushd "$BACKUPPATH" &>>$LOG_FILE; then
 					assertionFailed $LINENO "push to $BACKUPPATH failed"
 				fi
-				local dir_to_check
-				local tobeCheckedBackups=$(ls -d ${HOSTNAME_OSR}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_")
+				tobeCheckedBackups=$(ls -d ${HOSTNAME_OSR}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_")
 				echo "$tobeCheckedBackups" | while read dir_to_check; do
 					[[ -n $dir_to_check ]] && echo "!!! Matching backup found: $BACKUPTARGET_ROOT/${dir_to_check}"
 				done

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -1839,11 +1839,11 @@ MSG_EN[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup strategy wou
 MSG_DE[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup Strategie würde %s Backup löschen."
 MSG_FI[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Varmuuskopiointistrategia poistaisi kohteen %s."
 MSG_OLD_TYPE_BACKUPS_FOUND=402
-MSG_EN[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Old-type backups foundi (without OS info in its Name):"
+MSG_EN[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Old-type backups found (without OS info in its Name):"
 MSG_DE[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Backups vom alten Typ gefunden (ohne OS-Info im Namen):"
 MSG_OLD_TYPE_BACKUPS_HANDLING_INFO=403
 MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: They might be deleted manually. Best when there are enough new-type ones."
-MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: Diese könnten manuell gelöcht werden. Sinnvollerweise, wenn genügend neue Backups existieren."
+MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: Diese können manuell gelöscht werden. Sinnvollerweise, wenn genügend neue Backups existieren."
 MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL=404
 MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL]="RBK0404W: \"Enough\" means: if numListedNewBackups (%s)  has reached  keepBackups (%s)."
 MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL]="RBK0404W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
@@ -1853,6 +1853,9 @@ MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART]="RBK0405W: \"Genügend\" meint
 MSG_GENERIC_WARNING=406
 MSG_EN[$MSG_GENERIC_WARNING]="RBK0406W: %s"
 MSG_DE[$MSG_GENERIC_WARNING]="RBK0406W: %s"
+MSG_BACKUP_NAMING_CHANGE=407
+MSG_EN[$MSG_BACKUP_NAMING_CHANGE]="RBK0407W: With raspiBackup version %s the naming of the backup directories changed!"
+MSG_DE[$MSG_BACKUP_NAMING_CHANGE]="RBK0407W: Ab raspiBackup Version %s hat sich die Bezeichnung der Backup-Verzeichnisse geändert!"
 
 #
 # Non NLS messages
@@ -6295,7 +6298,8 @@ function reportOldBackups() {
 	tobeListedOldBackups=$(ls -d ${HOSTNAME}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_")
 
 	if [[ -n $tobeListedOldBackups ]] ; then
-		writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? "
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_BACKUP_NAMING_CHANGE "0.6.10.0"
 		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_FOUND
 		echo "$tobeListedOldBackups" | while read dir_to_list; do
 			[[ -n $dir_to_list ]] && writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "  - $BACKUPTARGET_ROOT/${dir_to_list}"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -5664,7 +5664,7 @@ function backupRsync() { # partition number (for partition based backup)
 		source="/"
 
 		bootPartitionBackup
-		lastBackupDir=$(find "$BACKUPTARGET_ROOT" -maxdepth 1 -type d -name "${HOSTNAME_OSR}*-$BACKUPTYPE-*" ! -name $BACKUPFILE 2>>/dev/null | sort | tail -n 1)
+		lastBackupDir=$(find "$BACKUPTARGET_ROOT" -maxdepth 1 -type d -name "${HOSTNAME_OSR}-$BACKUPTYPE-*" ! -name $BACKUPFILE 2>>/dev/null | sort | tail -n 1)
 		excludeRoot=""
 		excludeMeta="--exclude=/$BACKUPFILES_PARTITION_DATE.img --exclude=/$BACKUPFILES_PARTITION_DATE.tmg --exclude=/$BACKUPFILES_PARTITION_DATE.sfdisk --exclude=/$BACKUPFILES_PARTITION_DATE.blkid --exclude=/$BACKUPFILES_PARTITION_DATE.fdisk --exclude=/$BACKUPFILES_PARTITION_DATE.parted --exclude=/$BACKUPFILES_PARTITION_DATE.mbr --exclude=/$MYNAME.log --exclude=/$MYNAME.msg"
 	fi

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -7292,8 +7292,8 @@ function findNonpartitionBackupBootAndRootpartitionFiles() {
 	if [[ -f "$RESTOREFILE" || $BACKUPTYPE == $BACKUPTYPE_RSYNC ]]; then
 		ROOT_RESTOREFILE="$RESTOREFILE"
 	else
-		logItem "${RESTOREFILE}/${HOSTNAME}-*-backup*"
-		ROOT_RESTOREFILE="$(ls ${RESTOREFILE}/${HOSTNAME}-*-backup*)"
+		logItem "${RESTOREFILE}/${HOSTNAME}*-*-backup*"
+		ROOT_RESTOREFILE="$(ls ${RESTOREFILE}/${HOSTNAME}*-*-backup*)"
 		logItem "ROOT_RESTOREFILE: $ROOT_RESTOREFILE"
 		if [[ -z "$ROOT_RESTOREFILE" ]]; then
 			writeToConsole $MSG_LEVEL_MINIMAL $MSG_NO_ROOTBACKUPFILE_FOUND $BACKUPTYPE

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -1838,6 +1838,21 @@ MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED=401
 MSG_EN[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup strategy would delete %s."
 MSG_DE[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup Strategie würde %s Backup löschen."
 MSG_FI[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Varmuuskopiointistrategia poistaisi kohteen %s."
+MSG_OLD_TYPE_BACKUPS_FOUND=402
+MSG_EN[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Old-type backups foundi (without OS info in its Name):"
+MSG_DE[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Backups vom alten Typ gefunden (ohne OS-Info im Namen):"
+MSG_OLD_TYPE_BACKUPS_HANDLING_INFO=403
+MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: They might be deleted manually. Best when there are enough new-type ones."
+MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: Diese könnten manuell gelöcht werden. Sinnvollerweise, wenn genügend neue Backups existieren."
+MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL=404
+MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL]="RBK0404W: \"Enough\" means: if numListedNewBackups (%s)  has reached  keepBackups (%s)."
+MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL]="RBK0404W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
+MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART=405
+MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART]="RBK0405W: \"Enough\" means: if numListedNewBackups (%s)  or  numKeptBackups (%s)  has reached  keepBackups (%s)."
+MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART]="RBK0405W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  oder  numKeptBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
+MSG_GENERIC_WARNING=406
+MSG_EN[$MSG_GENERIC_WARNING]="RBK0406W: %s"
+MSG_DE[$MSG_GENERIC_WARNING]="RBK0406W: %s"
 
 #
 # Non NLS messages
@@ -6280,16 +6295,18 @@ function reportOldBackups() {
 	tobeListedOldBackups=$(ls -d ${HOSTNAME}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_")
 
 	if [[ -n $tobeListedOldBackups ]] ; then
-		echo "!!! **********************************************************************"
-		echo "!!! Old-type backups found:"
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? ? "
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_FOUND
 		echo "$tobeListedOldBackups" | while read dir_to_list; do
-			[[ -n $dir_to_list ]] && echo "!!!  - $BACKUPTARGET_ROOT/${dir_to_list}"
+			[[ -n $dir_to_list ]] && writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "  - $BACKUPTARGET_ROOT/${dir_to_list}"
 		done
-		echo "!!! These old-type backups might be deleted manually when there are enough new-type ones."
-		echo -e "!!! \"Enough\" means: if numListedNewBackups ($numListedNewBackups) \c"
-		(( $SMART_RECYCLE )) && echo -e " or  numKeptBackups ($numKeptBackups) \c"
-		echo " has reached  keepBackups (${keepBackups:-$DEFAULT_KEEPBACKUPS})"
-		echo "!!! **********************************************************************"
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_HANDLING_INFO
+		if (( $SMART_RECYCLE )) ; then
+			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART $numListedNewBackups $numKeptBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
+		else
+			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL $numListedNewBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
+		fi
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	fi
 
 	if ! popd &>>$LOG_FILE; then

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -1862,9 +1862,6 @@ MSG_DE[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO_SMART]="RBK0407W: \"Genügend\" meint
 MSG_OLD_NAME_BACKUPS_COUNTER_INFO=408
 MSG_EN[$MSG_OLD_NAME_BACKUPS_COUNTER_INFO]="RBK0408W: Note: This message will be shown again %s times."
 MSG_DE[$MSG_OLD_NAME_BACKUPS_COUNTER_INFO]="RBK0408W: Hinweis: Diese Meldung wird weitere %s Mal angezeigt werden."
-MSG_OLD_NAME_BACKUPS_COUNTER_INFO_BYE=409
-MSG_EN[$MSG_OLD_NAME_BACKUPS_COUNTER_INFO_BYE]="RBK0409W: Note: This message will no longer be shown from now on."
-MSG_DE[$MSG_OLD_NAME_BACKUPS_COUNTER_INFO_BYE]="RBK0409W: Hinweis: Diese Meldung wird zukünftig nicht mehr angezeigt werden."
 
 
 #
@@ -6325,12 +6322,12 @@ function reportOldBackups() {
 
 		# retrieve counter
 		local rf
-		rf="$(<$report_counter_file)"
+		rf=$(<$report_counter_file)
 		if [[ -z "${rf}" ]]; then				# counter file exists but is empty
 			echo "$DEFAULT_REPORT_COUNTER" > "$report_counter_file"
 			return
 		fi
-		rf=( $(<$report_counter_file) )
+		rf=$(<$report_counter_file)
 
 		# only print report if counter says so
 		if (( $rf > 0 )); then
@@ -6353,11 +6350,7 @@ function reportOldBackups() {
 			else
 				writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_HANDLING_INFO_NORMAL $numListedNewBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
 			fi
-			if (( $rfn > 0 )) ; then
-				writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_COUNTER_INFO "${rfn}"
-			else
-				writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_COUNTER_INFO_BYE
-			fi
+			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_COUNTER_INFO "${rfn}"
 
 			writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -8773,7 +8773,7 @@ function SR_listMonthlyBackups() { # directory
 			# today is 20191117
 			# date -d "$(date +%Y%m15) -0 month" +%Y%m -> 201911
 			local d=$(date -d "$(date +%Y%m15) -${i} month" +%Y%m) # get month
-			ls -1 $1 | egrep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earlies monthly backup
+			ls -1 $1 | egrep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earliest monthly backup
 		done
 	fi
 	logExit

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -6271,17 +6271,19 @@ function reportOldBackups() {
 
 	tobeListedOldBackups=$(ls -d ${HOSTNAME}-${BACKUPTYPE}-backup-* 2>>$LOG_FILE| grep -vE "_")
 
-	echo "$tobeListedOldBackups" | while read dir_to_list; do
-		[[ -n $dir_to_list ]] && echo "!!! Old-type backup found: $BACKUPTARGET_ROOT/${dir_to_list}"
-	done
-	if [[ -n "$tobeListedOldBackups" ]] ; then
-		echo "!!! Above listed old-type backups might be deleted manually when there are enough new-type ones."
+	if [[ -n $tobeListedOldBackups ]] ; then
+		echo "!!! **********************************************************************"
+		echo "!!! Old-type backups found:"
+		echo "$tobeListedOldBackups" | while read dir_to_list; do
+			[[ -n $dir_to_list ]] && echo "!!!  - $BACKUPTARGET_ROOT/${dir_to_list}"
+		done
+		echo "!!! These old-type backups might be deleted manually when there are enough new-type ones."
 		echo -e "!!! \"Enough\" means: if numListedNewBackups ($numListedNewBackups) \c"
-		if (( $SMART_RECYCLE )); then
-			echo -e " or  numKeptBackups ($numKeptBackups) \c"
-		fi
+		(( $SMART_RECYCLE )) && echo -e " or  numKeptBackups ($numKeptBackups) \c"
 		echo " has reached  keepBackups (${keepBackups:-$DEFAULT_KEEPBACKUPS})"
+		echo "!!! **********************************************************************"
 	fi
+
 	if ! popd &>>$LOG_FILE; then
 		assertionFailed $LINENO "pop failed"
 	fi

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -8642,7 +8642,7 @@ function SR_listYearlyBackups() { # directory
 			# today is 20191117
 			# date +%Y -d "0 year ago" -> 2019
 			local d=$(date +%Y -d "${i} year ago")
-			ls -1 $1 | egrep "\-${BACKUPTYPE}\-backup\-$d[0-9]{2}[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earliest yearly backup
+			ls -1 $1 | egrep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d[0-9]{2}[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earliest yearly backup
 		done
 	fi
 	logExit
@@ -8658,7 +8658,7 @@ function SR_listMonthlyBackups() { # directory
 			# today is 20191117
 			# date -d "$(date +%Y%m15) -0 month" +%Y%m -> 201911
 			local d=$(date -d "$(date +%Y%m15) -${i} month" +%Y%m) # get month
-			ls -1 $1 | egrep "\-${BACKUPTYPE}\-backup\-$d[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earlies monthly backup
+			ls -1 $1 | egrep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d[0-9]{2}" | grep -Ev "_" | sort -ur | tail -n 1 # find earlies monthly backup
 		done
 	fi
 	logExit
@@ -8681,7 +8681,7 @@ function SR_listWeeklyBackups() { # directory
 			local mon=$(date +%Y%m%d -d "$last monday -${i} weeks") # calculate monday of week
 			local dl=""
 			for ((d=0;d<=6;d++)); do	# now build list of week days of week (mon-sun)
-				dl="\-${BACKUPTYPE}\-backup\-$(date +%Y%m%d -d "$mon + $d day") $dl"
+				dl="${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$(date +%Y%m%d -d "$mon + $d day") $dl"
 			done
 			ls -1 $1 | grep -e "$(echo -n $dl | sed "s/ /\\\|/g")" | grep -Ev "_" | sort -ur | tail -n 1 # use earliest backup of this week
 		done
@@ -8697,7 +8697,7 @@ function SR_listDailyBackups() { # directory
 			# today is 20191117
 			# date +%Y%m%d -d "-1 day" -> 20191116
 			local d=$(date +%Y%m%d -d "-${i} day") # get day
-			ls -1 $1 | grep "\-${BACKUPTYPE}\-backup\-$d" | grep -Ev "_" | sort -ur | head -n 1 # find most current backup of this day
+			ls -1 $1 | grep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-$d" | grep -Ev "_" | sort -ur | head -n 1 # find most current backup of this day
 		done
 	fi
 	logExit
@@ -8739,7 +8739,7 @@ function SR_listUniqueBackups() { #directory
 
 function SR_listBackupsToDelete() { # directory
 	logEntry $1
-	local r="$(ls -1 $1 | grep -v -e "$(echo -n $(SR_listUniqueBackups "$1") -e "_" | sed "s/ /\\\|/g")" | grep "\-${BACKUPTYPE}\-backup\-" )" # make sure to delete only backup type files
+	local r="$(ls -1 $1 | grep -v -e "$(echo -n $(SR_listUniqueBackups "$1") -e "_" | sed "s/ /\\\|/g")" | grep "${HOSTNAME_OSR}\-${BACKUPTYPE}\-backup\-" )" # make sure to delete only backup type files
 	local rc="$(countLines "$r")"
 	logItem "$r"
 	echo "$r"

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -7202,7 +7202,7 @@ function doitBackup() {
 	# now either execute a SR dryrun or start backup
 
 	if (( $SMART_RECYCLE_DRYRUN && $SMART_RECYCLE )); then # just apply backup strategy to test smart recycle
-		writeToConsole $MSG_LEVEL_MINIMAL $MSG_APPLYING_BACKUP_STRATEGY_ONLY "$BACKUPPATH/$(hostname)"
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_APPLYING_BACKUP_STRATEGY_ONLY "$BACKUPPATH"
 		applyBackupStrategy
 		rc=0
 	else

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -1831,31 +1831,34 @@ MSG_DE[$MSG_NO_FILEATTRIBUTE_RIGHTS]="RBK0266E: Es fehlt die Berechtigung um Lin
 MSG_FI[$MSG_NO_FILEATTRIBUTE_RIGHTS]="RBK0266E: Käyttöoikeudet tiedostoattribuuttien luomiseen puuttuvat kohteesta %s (Tiedostojärjestelmä: %s)."
 MSG_FR[$MSG_NO_FILEATTRIBUTE_RIGHTS]="RBK0266E: Droits d'accès manquants pour créer des attributs de fichier sur %s (système de fichiers : %s)."
 
-MSG_EXISTING_BACKUP=400
-MSG_EN[$MSG_EXISTING_BACKUP]="RBK0400I: Existing backup: %s"
-MSG_DE[$MSG_EXISTING_BACKUP]="RBK0400I: Existierendes Backup: %s"
-MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED=401
-MSG_EN[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup strategy would delete %s."
-MSG_DE[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Backup Strategie würde %s Backup löschen."
-MSG_FI[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0401W: Varmuuskopiointistrategia poistaisi kohteen %s."
-MSG_OLD_TYPE_BACKUPS_FOUND=402
-MSG_EN[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Old-type backups found (without OS info in its Name):"
-MSG_DE[$MSG_OLD_TYPE_BACKUPS_FOUND]="RBK0402W: Backups vom alten Typ gefunden (ohne OS-Info im Namen):"
-MSG_OLD_TYPE_BACKUPS_HANDLING_INFO=403
-MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: They might be deleted manually. Best when there are enough new-type ones."
-MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO]="RBK0403W: Diese können manuell gelöscht werden. Sinnvollerweise, wenn genügend neue Backups existieren."
-MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL=404
-MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL]="RBK0404W: \"Enough\" means: if numListedNewBackups (%s)  has reached  keepBackups (%s)."
-MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL]="RBK0404W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
-MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART=405
-MSG_EN[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART]="RBK0405W: \"Enough\" means: if numListedNewBackups (%s)  or  numKeptBackups (%s)  has reached  keepBackups (%s)."
-MSG_DE[$MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART]="RBK0405W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  oder  numKeptBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
-MSG_GENERIC_WARNING=406
-MSG_EN[$MSG_GENERIC_WARNING]="RBK0406W: %s"
-MSG_DE[$MSG_GENERIC_WARNING]="RBK0406W: %s"
-MSG_BACKUP_NAMING_CHANGE=407
-MSG_EN[$MSG_BACKUP_NAMING_CHANGE]="RBK0407W: With raspiBackup version %s the naming of the backup directories changed!"
-MSG_DE[$MSG_BACKUP_NAMING_CHANGE]="RBK0407W: Ab raspiBackup Version %s hat sich die Bezeichnung der Backup-Verzeichnisse geändert!"
+MSG_GENERIC_WARNING=400
+MSG_EN[$MSG_GENERIC_WARNING]="RBK0400W: %s"
+MSG_DE[$MSG_GENERIC_WARNING]="RBK0400W: %s"
+
+MSG_EXISTING_BACKUP=401
+MSG_EN[$MSG_EXISTING_BACKUP]="RBK0401I: Existing backup: %s"
+MSG_DE[$MSG_EXISTING_BACKUP]="RBK0401I: Existierendes Backup: %s"
+MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED=402
+MSG_EN[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0402W: Backup strategy would delete %s."
+MSG_DE[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0402W: Backup Strategie würde %s Backup löschen."
+MSG_FI[$MSG_NORMAL_RECYCLE_FILE_WOULD_BE_DELETED]="RBK0402W: Varmuuskopiointistrategia poistaisi kohteen %s."
+
+MSG_BACKUP_NAMING_CHANGE=403
+MSG_EN[$MSG_BACKUP_NAMING_CHANGE]="RBK0403W: With raspiBackup version %s the naming of the backup directories changed!"
+MSG_DE[$MSG_BACKUP_NAMING_CHANGE]="RBK0403W: Ab raspiBackup Version %s hat sich die Bezeichnung der Backup-Verzeichnisse geändert!"
+MSG_OLD_NAME_BACKUPS_FOUND=404
+MSG_EN[$MSG_OLD_NAME_BACKUPS_FOUND]="RBK0404W: Old-name backups found (without OS info in its name):"
+MSG_DE[$MSG_OLD_NAME_BACKUPS_FOUND]="RBK0404W: Backups mit alter Bezeichnung gefunden (ohne OS-Info im Namen):"
+MSG_OLD_NAME_BACKUPS_HANDLING_INFO=405
+MSG_EN[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO]="RBK0405W: They might be deleted manually. Best when there are enough new-type ones."
+MSG_DE[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO]="RBK0405W: Diese können manuell gelöscht werden. Sinnvollerweise, wenn genügend neue Backups existieren."
+MSG_OLD_NAME_BACKUPS_HANDLING_INFO_NORMAL=406
+MSG_EN[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO_NORMAL]="RBK0406W: \"Enough\" means: if numListedNewBackups (%s)  has reached  keepBackups (%s)."
+MSG_DE[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO_NORMAL]="RBK0406W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
+MSG_OLD_NAME_BACKUPS_HANDLING_INFO_SMART=407
+MSG_EN[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO_SMART]="RBK0407W: \"Enough\" means: if numListedNewBackups (%s)  or  numKeptBackups (%s)  has reached  keepBackups (%s)."
+MSG_DE[$MSG_OLD_NAME_BACKUPS_HANDLING_INFO_SMART]="RBK0407W: \"Genügend\" meint: Wenn numListedNewBackups (%s)  oder  numKeptBackups (%s)  den Wert von  keepBackups (%s) erreicht hat."
+
 
 #
 # Non NLS messages
@@ -6300,15 +6303,15 @@ function reportOldBackups() {
 	if [[ -n $tobeListedOldBackups ]] ; then
 		writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 		writeToConsole $MSG_LEVEL_MINIMAL $MSG_BACKUP_NAMING_CHANGE "0.6.10.0"
-		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_FOUND
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_FOUND
 		echo "$tobeListedOldBackups" | while read dir_to_list; do
 			[[ -n $dir_to_list ]] && writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "  - $BACKUPTARGET_ROOT/${dir_to_list}"
 		done
-		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_HANDLING_INFO
+		writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_HANDLING_INFO
 		if (( $SMART_RECYCLE )) ; then
-			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_SMART $numListedNewBackups $numKeptBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
+			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_HANDLING_INFO_SMART $numListedNewBackups $numKeptBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
 		else
-			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_TYPE_BACKUPS_HANDLING_INFO_NORMAL $numListedNewBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
+			writeToConsole $MSG_LEVEL_MINIMAL $MSG_OLD_NAME_BACKUPS_HANDLING_INFO_NORMAL $numListedNewBackups ${keepBackups:-$DEFAULT_KEEPBACKUPS}
 		fi
 		writeToConsole $MSG_LEVEL_MINIMAL $MSG_GENERIC_WARNING "!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!"
 	fi

--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -6276,12 +6276,11 @@ function reportOldBackups() {
 	done
 	if [[ -n "$tobeListedOldBackups" ]] ; then
 		echo "!!! Above listed old-type backups might be deleted manually when there are enough new-type ones."
-		echo -e "!!! That means: if numListedNewBackups ($numListedNewBackups)  >=  \c"
+		echo -e "!!! \"Enough\" means: if numListedNewBackups ($numListedNewBackups) \c"
 		if (( $SMART_RECYCLE )); then
-			echo "numKeptBackups ($numKeptBackups)"
-		else
-			echo "keepBackups ($keepBackups)"
+			echo -e " or  numKeptBackups ($numKeptBackups) \c"
 		fi
+		echo " has reached  keepBackups (${keepBackups:-$DEFAULT_KEEPBACKUPS})"
 	fi
 	if ! popd &>>$LOG_FILE; then
 		assertionFailed $LINENO "pop failed"

--- a/test/raspiBackup7412Test.sh
+++ b/test/raspiBackup7412Test.sh
@@ -67,13 +67,6 @@ MASS=1
 TYPE=1
 
 HOSTNAME=$(hostname)
-# For including the OS release into the name of the backup directory
-os_release=$(getOSRelease)
-# Note: Sanitize the os_release to be usable as (part of) directory name.
-# But don't allow or use "-" or "_" as replacement character!
-# Both characters are already used as dividers/markers later on!
-# The "~" seems to be okay. Even safer would be "", a.k.a. nothing.
-HOSTNAME_OSR="${HOSTNAME}@${os_release//[ \/\\\:\.\-_]/\~}"
 
 function getOSRelease() {
 
@@ -240,6 +233,15 @@ function testSpecificBackups() { # lineNo stringlist_of_dates type numberOfstati
 		fi
 	done
 }
+
+# For including the OS release into the name of the backup directory
+os_release=$(getOSRelease)
+# Note: Sanitize the os_release to be usable as (part of) directory name.
+# But don't allow or use "-" or "_" as replacement character!
+# Both characters are already used as dividers/markers later on!
+# The "~" seems to be okay. Even safer would be "", a.k.a. nothing.
+HOSTNAME_OSR="${HOSTNAME}@${os_release//[ \/\\\:\.\-_]/\~}"
+
 
 # tests to execute for all timeframes
 # 1) check limit on option is used for timeframe

--- a/test/raspiBackup7412Test.sh
+++ b/test/raspiBackup7412Test.sh
@@ -180,6 +180,9 @@ function createMassBackups() { # startdate count #per_day type dont_delete_flag
 
 function testMassBackups() { # count type
 
+	#TODO: a) is this function used anywhere?
+	#      b) if yes: is HOSTNAME_OSR correct then? Just after "$DIR/"?
+
 	echo "Testing ..."
 
 	local f=$(ls $DIR/${HOSTNAME_OSR}-${2}/ | wc -l)
@@ -207,6 +210,9 @@ function testSpecificBackups() { # lineNo stringlist_of_dates type numberOfstati
 	fi
 
 	echo "Testing for type $type and static $((2*$static)) ..."
+
+	#TODO: do we need to filter HOSTNAME_OSR?
+	#      or/and do we need to check for old-named backups too?
 
 	local f=$(ls $DIR/${HOSTNAME}/ | grep $type | grep -v "_" | wc -l)
 	local n=$(wc -w <<< "$dtes")


### PR DESCRIPTION
Adding to issue #778 this is my attempt implementing a different naming scheme of the backup directories which includes the OS version.

Using
```
raspberrypi@debian12-rsync-backup-20240416-094106
```
instead of
```
raspberrypi-rsync-backup-20240416-094106
```

This way every time a new OS version is saved a new backup directory is created/used and thus a new full backup is created.

Possibly already existing backups with the old name (without OS release info) are simply ignored during smartRecycle and while checking the number of backups to keep.

I successfully tested backup and restore in different configurations.