### PR TITLE
#374 treat partition type as a string to handle GPT partitions

### DIFF
--- a/raspiBackup.sh
+++ b/raspiBackup.sh
@@ -7347,7 +7347,7 @@ function collectPartitions() {
 			size=${BASH_REMATCH[3]}
 			type=${BASH_REMATCH[5]}
 			logItem "partition: $partition - size: $size - type: $type"
-			if (( $type != 5 && $type != 85 && $size > 0 )); then # skip empty and extended partitions
+			if [[ "$type" != "5" && "$type" != "85" && "$size" -gt 0 ]]; then # skip empty and extended partitions
 				logItem "mount: $(mount)"
 				logItem "Partition: $partition"
 				mountLine=$(mount | grep "$partition" )


### PR DESCRIPTION
Please provide enough information so that others can review your pull request:

This change is a step towards supporting GPT partitions. Details explaining the reasoning are in #851 and #374.
With this patch, the backup of my GPT partition succeeds. Note that this is a small step towards the full support of GPT, but it is at least something that fixes the problem in my circumstances and it is fully backwards compatible, so there is no harm..

```

--- RBK0009I: storage: raspiBackup.sh V0.7.0.1 - 2025-03-02 (6bdac60) started at Wed 26 Mar 03:14:07 GMT 2025
--- RBK0116I: Using config file /usr/local/etc/raspiBackup.conf
--- RBK0031I: Checking whether a new version of raspiBackup.sh is available
--- RBK0151I: Using backuppath /home/pi/bin/GoogleDrive/Root/Backups/rpi with partition type fuse.rclone
--- RBK0008I: Stopping services: 'systemctl stop zoneminder && systemctl stop apache2 && systemctl stop mariadb && systemctl stop nmbd && systemctl stop smbd && systemctl stop cron'
--- RBK0267I: Extension raspiBackup_mem_pre.sh called
--- RBK0267I: Extension raspiBackup_temp_pre.sh called
--- RBK0267I: Extension raspiBackup_disk_pre.sh called
--- RBK0081I: Creating backup of type tgz in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/storage@debian12-tgz-backup-20250326-031407
--- RBK0347I: Partition oriented backup of type tgz started for partitions 1 2
--- RBK0036I: Saving partition layout
--- RBK0045I: Creating backup of partition layout in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/storage-backup.sfdisk
--- RBK0045I: Creating backup of partition layout in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/storage-backup.blkid
--- RBK0045I: Creating backup of partition layout in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/storage-backup.parted
--- RBK0045I: Creating backup of partition layout in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/storage-backup.fdisk
--- RBK0046I: Creating backup of master boot record in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/storage-backup.mbr
--- RBK0092I: Saving partition nvme0n1p1 (76.19 KiB/510.98 KiB)
--- RBK0158I: Creating native tgz backup /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/nvme0n1p1.tgz
--- RBK0085I: Backup of type tgz started. Please be patient
--- RBK0112I: Partition nvme0n1p1 was saved
--- RBK0092I: Saving partition nvme0n1p2 (79.79 MiB/118.51 MiB)
--- RBK0158I: Creating native tgz backup /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407/nvme0n1p2.tgz
--- RBK0085I: Backup of type tgz started. Please be patient
tar: ./var/lib/docker/overlay2/cd013d0a725076075f0d48dc67679ffe10bf69fab0962242169bd0660592ed66/diff/tmp/dotnet-diagnostic-29-340024-socket: socket ignored
tar: ./var/lib/docker/overlay2/cd013d0a725076075f0d48dc67679ffe10bf69fab0962242169bd0660592ed66/diff/tmp/dotnet-diagnostic-29-1173-socket: socket ignored
tar: ./var/lib/docker/overlay2/cd013d0a725076075f0d48dc67679ffe10bf69fab0962242169bd0660592ed66/diff/tmp/dotnet-diagnostic-29-1179-socket: socket ignored
tar: ./home/pi/.cache/JetBrains/IdeaIC2024.1/.port: socket ignored
--- RBK0112I: Partition nvme0n1p2 was saved
--- RBK0078I: Backup time: 00:57:12
--- RBK0033I: Please wait until cleanup has finished
--- RBK0345I: Temporary backup directory /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/tmp/storage@debian12-tgz-backup-20250326-031407 moved to /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/storage@debian12-tgz-backup-20250326-031407
--- RBK0159I: 3 backups kept for tgz backup type. Please be patient
--- RBK0205I: Deleting oldest backup in /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage. This may take some time. Please be patient
!!! RBK0332W: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
!!! RBK0335W: With raspiBackup version 0.7 the naming of the backup directories changed!
!!! RBK0336W: Old-named backups found without OS info in its directory name:
!!! RBK0332W: - /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/storage-tgz-backup-20250212-031404
!!! RBK0332W: - /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/storage-tgz-backup-20250219-031348
!!! RBK0332W: - /home/pi/bin/GoogleDrive/Root/Backups/rpi/storage/storage-tgz-backup-20250305-031350
!!! RBK0337W: They are not included in the backup recycle process and have to be deleted manually
!!! RBK0338W: Note: This message will be shown again 3 times
!!! RBK0332W: !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!
--- RBK0267I: Extension raspiBackup_mem_post.sh called
--- RBK1001I: Memory usage pre backup - Used: 554 MB Free: 3881 MB
--- RBK1001I: Memory usage post backup - Used: 582 MB Free: 918 MB
--- RBK0267I: Extension raspiBackup_temp_post.sh called
--- RBK1000I: CPU temperature pre and post backup: 59.3'C - 58.2'C
--- RBK0267I: Extension raspiBackup_disk_post.sh called
--- RBK1001I: Disk usage pre backup: Used: 1.38 TiB Free: 641.28 GiB
--- RBK1002I: Disk usage post backup: Used: 1.45 TiB Free: 573.99 GiB
--- RBK1003I: Disk usage change: -67.29 GiB (-10.00 %%)
--- RBK0007I: Starting services: 'systemctl start cron && systemctl start smbd && systemctl start nmbd && systemctl start mariadb && systemctl start apache2 && systemctl start zoneminder'
--- RBK0017I: Backup finished successfully
--- RBK0010I: storage: raspiBackup.sh V0.7.0.1 - 2025-03-02 (6bdac60) stopped at Wed 26 Mar 04:11:39 GMT 2025 with rc 0
--- RBK0167I: Sending email
```