### PR TITLE
Improve package removal for install test

### DIFF
--- a/build/install.sh
+++ b/build/install.sh
@@ -62,7 +62,7 @@ if [[ $cmd =~ ^-c ]]; then
 		echo ""
 	else
 		show "Removing raspiBackup ..."
-		sudo apt remove -y raspibackup || true
+		sudo apt purge -y raspibackup || true
 	fi
 fi
 


### PR DESCRIPTION
Workaround for the error "mv: cannot stat '/etc/raspiBackup/raspiBackup_en.conf': No such file or directory" when using `install.sh -c`. Not yet sure if that is a solution...