### PR TITLE
M 972: New target path. Variables. Several fixes to upper/lower case of raspiBackup. Lintian!

### DIFF
--- a/build/README.md
+++ b/build/README.md
@@ -17,13 +17,13 @@ Directories:
 │   ├── DEBIAN			# DEBIAN package source
 │   │   ├── conffiles	# definition of config files
 │   │   ├── control		# package control file
-│   │   ├── postinst	# script executed after package installation 
+│   │   ├── postinst	# script executed after package installation
 │   │   └── postrm		# script executed after apt remove
 │   └── src				# deb package build directory
 │       ├── DEBIAN
-│       ├── etc
 │       └── usr
-├── raspiBackupInstall.sh	# draft public installation script, uses the deb and gpg key from github 
+│           └── local
+├── raspiBackupInstall.sh	# draft public installation script, uses the deb and gpg key from github
 └── README.md
 
 ```

--- a/build/README.md
+++ b/build/README.md
@@ -10,7 +10,6 @@ Directories:
 ├── common.sh			# common definitions for build and install
 ├── compareVersions.sh	# script used to test version up- and downgrade recognition
 ├── deb					# directory which receives the built deb packages
-├── gitsrc				# clone of raspiBackup repository used to populate package directory
 ├── gpg.conf			# gpg key id used to sign the packages
 ├── install.log			# installation log
 ├── install.sh			# install packages

--- a/build/build.sh
+++ b/build/build.sh
@@ -133,7 +133,7 @@ popd > /dev/null
 git worktree remove "$GITSRC"
 
 # Insert commit date and sha1 into the scripts
-sed -i -e "s/\\\$Date\\\$/\\\$Date: $last_date\\\$/g" -e "s/\\\$Sha1\\\$/\\\$Sha1: $sha1\\\$/g" "$TGT/$DIR_SHARE/${PACKAGE_NAME}"/*
+sed -i -e "s/\\\$Date\\\$/\\\$Date: $last_date\\\$/g" -e "s/\\\$Sha1\\\$/\\\$Sha1: $sha1\\\$/g" "$TGT/$DIR_BIN"/raspiBackup* "$TGT/$DIR_SHARE/${PACKAGE_NAME}"/*
 
 # copy doc files (copyright in this case)
 # TODO: Fix copyright file to make lintian happy

--- a/build/build.sh
+++ b/build/build.sh
@@ -83,13 +83,14 @@ if (( $# > 0 )); then
 fi
 
 # Debian wants to have all-lowercase package names
-PACKAGE_NAME="raspibackup"
+export PACKAGE_NAME="raspibackup"
 
-# relative pathes for the files in the package
-DIR_BIN="usr/local/bin"
-DIR_ETC="usr/local/etc"
-DIR_LIB="usr/local/lib"
-DIR_SHARE="usr/local/share"
+# absolute pathes for the files in the package
+# will be used relatively below and absolutely in envsubst results
+export DIR_BIN="/usr/local/bin"
+export DIR_ETC="/usr/local/etc"
+export DIR_LIB="/usr/local/lib"
+export DIR_SHARE="/usr/local/share"
 
 # underscores are not allowed in Debian version numbers
 # change m_972 to m-972
@@ -138,11 +139,22 @@ sed -i -e "s/\\\$Date\\\$/\\\$Date: $last_date\\\$/g" -e "s/\\\$Sha1\\\$/\\\$Sha
 # TODO: Fix copyright file to make lintian happy
 install -m644 -D -t "$TGT/$DIR_SHARE/doc/${PACKAGE_NAME}" "$PACKAGE/DEBIAN/copyright"
 
+mkdir -p "$TGT/DEBIAN"
 # create DEBIAN package files and insert version number in control file
-install -m644 -D -t "$TGT/DEBIAN" "$PACKAGE/DEBIAN/conffiles"
-install -m755    -t "$TGT/DEBIAN" "$PACKAGE/DEBIAN/postinst" "$PACKAGE/DEBIAN/postrm"
-envsubst < "$PACKAGE/DEBIAN/control" >  "$TGT/DEBIAN/control"
-chmod 644 "$TGT/DEBIAN/control"
+envsubst < "$PACKAGE/DEBIAN/control"   > "$TGT/DEBIAN/control"
+envsubst < "$PACKAGE/DEBIAN/conffiles" > "$TGT/DEBIAN/conffiles"
+envsubst < "$PACKAGE/DEBIAN/postinst"  > "$TGT/DEBIAN/postinst"
+envsubst < "$PACKAGE/DEBIAN/postrm"    > "$TGT/DEBIAN/postrm"
+chmod 644 "$TGT/DEBIAN/conffiles" "$TGT/DEBIAN/control"
+chmod 755 "$TGT/DEBIAN/postinst" "$TGT/DEBIAN/postrm"
+
+show "Resulting DEBIAN package files ..."
+
+for f in "$TGT"/DEBIAN/* ; do
+    echo ""
+    show "... $f"
+    cat "$f"
+done
 
 exec 1> >(stdbuf -i0 -o0 -e0 tee -ia "$LOG_FILE")
 exec 2> >(stdbuf -i0 -o0 -e0 tee -ia "$LOG_FILE" >&2)

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,11 +31,16 @@ GITSRC=$(mktemp --tmpdir -d raspiBackup_gitsrc4deb.XXXXXX)
 # shellcheck disable=2034
 readonly GITSRC
 
-BRANCH_TO_DEB="m_972_testing"
+# The branch used to build the Debian package from.
+# If empty then the curent branch is used.
+# Note: Always only the commited changes are taken into account!
 # BRANCH_TO_DEB="master"
+# BRANCH_TO_DEB="m_972"
+BRANCH_TO_DEB=""
 
 CURRENT_BRANCH=$(git branch --show-current)
 
+BRANCH_TO_DEB="${BRANCH_TO_DEB:-${CURRENT_BRANCH}}"
 show "Using branch '$BRANCH_TO_DEB' as source for the build"
 
 if [[ "$CURRENT_BRANCH" == "$BRANCH_TO_DEB" ]] ; then

--- a/build/build.sh
+++ b/build/build.sh
@@ -150,14 +150,15 @@ exec 1> >(stdbuf -i0 -o0 -e0 tee -ia "$LOG_FILE")
 exec 2> >(stdbuf -i0 -o0 -e0 tee -ia "$LOG_FILE" >&2)
 
 rm "$LOG_FILE" || true
-rc=1
+rc=0
 
 show "Build package"
-dpkg-deb --root-owner-group --build "$TGT" "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
+LC_ALL=C dpkg-deb --root-owner-group --build "$TGT" "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
 
 if [[ -n "$GPG_KEYID" ]] ; then
 	show "Sign package"
 	gpg --verbose --yes --detach-sign -u "$GPG_KEYID" "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
+	rc=$?
 else
 	echo ""
 	echo "Error: The package can't be signed!"
@@ -174,6 +175,10 @@ EOF_GPG
 	echo "         Please fill in the correct ID and build again!"
 	echo ""
 	rc=1
+fi
+
+if [[ "$rc" -ne 0 ]] ; then
+    exit "$rc"
 fi
 
 show "Show files which will be installed"
@@ -197,14 +202,21 @@ if (( CHECK_PACKAGE != 0 )) ; then
 	show "Check package with lintian "
 
 	if command -v lintian > /dev/null ; then
-		# Note: The default behaviour for rc=2 is: `--fail-on error`
-		#       But since there are still several know errors we ignore them for now.
+		# Note: The default behaviour for lintian exiting with rc=2 is:
+		#         `--fail-on error`
+		#       Since this packet isn't a real Debian one there are some
+		#       "accepted" errors. We simply **could** ignore all of the
+		#       failing checks by using option '--fail-on pedantic'.
+		#       But the cleaner way is:
+		#       Only suppress the unwanted checks via --suppress_tags:
 		SUPPRESS_TAGS="--suppress-tags file-in-unusual-dir"
 		SUPPRESS_TAGS="$SUPPRESS_TAGS,dir-in-usr-local,file-in-usr-local"
 		SUPPRESS_TAGS="$SUPPRESS_TAGS,file-in-usr-marked-as-conffile,non-etc-file-marked-as-conffile"
 		SUPPRESS_TAGS="$SUPPRESS_TAGS,no-changelog"
+		# SUPPRESS_TAGS="$SUPPRESS_TAGS,no-copyright-file"
+		#
 		# shellcheck disable=2086  # Double quote to prevent globbing and word splitting
-		lintian --color always --fail-on pedantic $SUPPRESS_TAGS "$DEB_TGT/${PACKAGE_NAME}.deb"
+		lintian --color always $SUPPRESS_TAGS "$DEB_TGT/${PACKAGE_NAME}.deb"
 		rc=$?
 	else
 		echo "Warning: Can't check package because 'lintian' isn't installed!"

--- a/build/build.sh
+++ b/build/build.sh
@@ -185,7 +185,11 @@ if (( CHECK_PACKAGE != 0 )) ; then
 	if command -v lintian > /dev/null ; then
 		# Note: The default behaviour for rc=2 is: `--fail-on error`
 		#       But since there are still several know errors we ignore them for now.
-		lintian --color always --fail-on pedantic "$DEB_TGT/raspiBackup.deb"
+		SUPPRESS_TAGS="--suppress-tags file-in-unusual-dir"
+		SUPPRESS_TAGS="$SUPPRESS_TAGS,dir-in-usr-local,file-in-usr-local"
+		SUPPRESS_TAGS="$SUPPRESS_TAGS,file-in-usr-marked-as-conffile,non-etc-file-marked-as-conffile"
+		# shellcheck disable=2086  # Double quote to prevent globbing and word splitting
+		lintian --color always --fail-on pedantic $SUPPRESS_TAGS "$DEB_TGT/${PACKAGE_NAME}.deb"
 		rc=$?
 	else
 		echo "Warning: Can't check package because 'lintian' isn't installed!"

--- a/build/build.sh
+++ b/build/build.sh
@@ -31,7 +31,7 @@ GITSRC=$(mktemp --tmpdir -d raspiBackup_gitsrc4deb.XXXXXX)
 # shellcheck disable=2034
 readonly GITSRC
 
-BRANCH_TO_DEB="m_972"
+BRANCH_TO_DEB="m_972_testing"
 # BRANCH_TO_DEB="master"
 
 CURRENT_BRANCH=$(git branch --show-current)

--- a/build/build.sh
+++ b/build/build.sh
@@ -202,6 +202,7 @@ if (( CHECK_PACKAGE != 0 )) ; then
 		SUPPRESS_TAGS="--suppress-tags file-in-unusual-dir"
 		SUPPRESS_TAGS="$SUPPRESS_TAGS,dir-in-usr-local,file-in-usr-local"
 		SUPPRESS_TAGS="$SUPPRESS_TAGS,file-in-usr-marked-as-conffile,non-etc-file-marked-as-conffile"
+		SUPPRESS_TAGS="$SUPPRESS_TAGS,no-changelog"
 		# shellcheck disable=2086  # Double quote to prevent globbing and word splitting
 		lintian --color always --fail-on pedantic $SUPPRESS_TAGS "$DEB_TGT/${PACKAGE_NAME}.deb"
 		rc=$?

--- a/build/build.sh
+++ b/build/build.sh
@@ -139,12 +139,10 @@ sed -i -e "s/\\\$Date\\\$/\\\$Date: $last_date\\\$/g" -e "s/\\\$Sha1\\\$/\\\$Sha
 install -m644 -D -t "$TGT/$DIR_SHARE/doc/${PACKAGE_NAME}" "$PACKAGE/DEBIAN/copyright"
 
 # create DEBIAN package files and insert version number in control file
-envsubst < "$PACKAGE/DEBIAN/control" > /tmp/control
-install -m644 -D /tmp/control "$TGT/DEBIAN/control"
-rm /tmp/control
-install -m644  "$PACKAGE/DEBIAN/conffiles" "$TGT/DEBIAN"
-install -m755  "$PACKAGE/DEBIAN/postinst" "$TGT/DEBIAN"
-install -m755  "$PACKAGE/DEBIAN/postrm" "$TGT/DEBIAN"
+install -m644 -D -t "$TGT/DEBIAN" "$PACKAGE/DEBIAN/conffiles"
+install -m755    -t "$TGT/DEBIAN" "$PACKAGE/DEBIAN/postinst" "$PACKAGE/DEBIAN/postrm"
+envsubst < "$PACKAGE/DEBIAN/control" >  "$TGT/DEBIAN/control"
+chmod 644 "$TGT/DEBIAN/control"
 
 exec 1> >(stdbuf -i0 -o0 -e0 tee -ia "$LOG_FILE")
 exec 2> >(stdbuf -i0 -o0 -e0 tee -ia "$LOG_FILE" >&2)

--- a/build/build.sh
+++ b/build/build.sh
@@ -77,35 +77,44 @@ if (( $# > 0 )); then
 	VERSION="$1"
 fi
 
-# underscores are not allowed in debian version numbers
+# Debian wants to have all-lowercase package names
+PACKAGE_NAME="raspibackup"
+
+# relative pathes for the files in the package
+DIR_BIN="usr/local/bin"
+DIR_ETC="usr/local/etc"
+DIR_LIB="usr/local/lib"
+DIR_SHARE="usr/local/share"
+
+# underscores are not allowed in Debian version numbers
 # change m_972 to m-972
 VERSION="$(sed -E 's/_/-/g' <<< "$VERSION")"
 VERSION_FILES="_$(sed -E 's/_/./g' <<< "$VERSION")"
 
-show "Building deb package for raspiBackup $VERSION"
+show "Building deb package '${PACKAGE_NAME}' for raspiBackup $VERSION"
 
 rm -rf "$TGT"
 rm -rf "$DEB_TGT"
 mkdir -p "$DEB_TGT"
 
 # copy source files
-install -m755 -D -t "$TGT/usr/share/raspiBackup" "$GITSRC/raspiBackup.sh" "$GITSRC/installation/raspiBackupInstallUI.sh"
+install -m755 -D -t "$TGT/$DIR_BIN" "$GITSRC/raspiBackup.sh" "$GITSRC/installation/raspiBackupInstallUI.sh"
 
 # create links
-pushd "$TGT/usr/share/raspiBackup" > /dev/null
+pushd "$TGT/$DIR_BIN" > /dev/null
 ln -s -r raspiBackup.sh raspiBackup
 ln -s -r raspiBackupInstallUI.sh raspiBackupInstallUI
 popd > /dev/null
 
 # copy config files - Note: They may contain credentials - therefore change to 600 during installation
-install -m644 -D -t "$TGT/etc/raspiBackup" "$GITSRC/config/raspiBackup_de.conf" "$GITSRC/config/raspiBackup_en.conf"
+install -m644 -D -t "$TGT/$DIR_ETC/${PACKAGE_NAME}" "$GITSRC/config/raspiBackup_de.conf" "$GITSRC/config/raspiBackup_en.conf"
 
 # copy systemd files
-install -m644 -D -t "$TGT/usr/lib/systemd/system" "$GITSRC/installation/raspiBackup.service" "$GITSRC/installation/raspiBackup.timer"
+install -m644 -D -t "$TGT/$DIR_LIB/systemd/system" "$GITSRC/installation/raspiBackup.service" "$GITSRC/installation/raspiBackup.timer"
 
 # copy extension files
 for file in "$GITSRC"/extensions/raspiBackup_*; do
-	install -m755 "$file" "$TGT/usr/share/raspiBackup"
+	install -m755 -D -t "$TGT/$DIR_SHARE/${PACKAGE_NAME}" "$file"
 done
 
 # get current commit sha and date into code
@@ -118,11 +127,11 @@ popd > /dev/null
 git worktree remove "$GITSRC"
 
 # Insert commit date and sha1 into the scripts
-sed -i -e "s/\\\$Date\\\$/\\\$Date: $last_date\\\$/g" -e "s/\\\$Sha1\\\$/\\\$Sha1: $sha1\\\$/g" "$TGT"/usr/share/raspiBackup/*
+sed -i -e "s/\\\$Date\\\$/\\\$Date: $last_date\\\$/g" -e "s/\\\$Sha1\\\$/\\\$Sha1: $sha1\\\$/g" "$TGT/$DIR_SHARE/${PACKAGE_NAME}"/*
 
 # copy doc files (copyright in this case)
 # TODO: Fix copyright file to make lintian happy
-install -m644 -D -t "$TGT/usr/share/doc/raspiBackup" "$PACKAGE/DEBIAN/copyright"
+install -m644 -D -t "$TGT/$DIR_SHARE/doc/${PACKAGE_NAME}" "$PACKAGE/DEBIAN/copyright"
 
 # create DEBIAN package files and insert version number in control file
 envsubst < "$PACKAGE/DEBIAN/control" > /tmp/control
@@ -139,11 +148,11 @@ rm "$LOG_FILE" || true
 rc=1
 
 show "Build package"
-dpkg-deb --root-owner-group --build "$TGT" "$DEB_TGT/raspiBackup$VERSION_FILES.deb"
+dpkg-deb --root-owner-group --build "$TGT" "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
 
 if [[ -n "$GPG_KEYID" ]] ; then
 	show "Sign package"
-	gpg --verbose --yes --detach-sign -u "$GPG_KEYID" "$DEB_TGT/raspiBackup$VERSION_FILES.deb"
+	gpg --verbose --yes --detach-sign -u "$GPG_KEYID" "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
 else
 	echo ""
 	echo "Error: The package can't be signed!"
@@ -163,19 +172,19 @@ EOF_GPG
 fi
 
 show "Show files which will be installed"
-dpkg-deb -c "$DEB_TGT/raspiBackup$VERSION_FILES.deb"
+dpkg-deb -c "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
 
 show "The final package in $DEB_TGT"
 ls -l "$DEB_TGT"
 
-show "raspiBackup $VERSION package information"
-dpkg-deb -I "$DEB_TGT/raspiBackup$VERSION_FILES.deb"
+show "${PACKAGE_NAME} $VERSION package information"
+dpkg-deb -I "$DEB_TGT/${PACKAGE_NAME}${VERSION_FILES}.deb"
 
 # create links
 pushd "$DEB_TGT" > /dev/null
-ln -sf "raspiBackup$VERSION_FILES.deb" "raspiBackup.deb"
+ln -sf "${PACKAGE_NAME}${VERSION_FILES}.deb" "${PACKAGE_NAME}.deb"
 if [[ -n "$GPG_KEYID" ]] ; then
-	ln -sf "raspiBackup$VERSION_FILES.deb.sig" "raspiBackup.deb.sig"
+	ln -sf "${PACKAGE_NAME}${VERSION_FILES}.deb.sig" "${PACKAGE_NAME}.deb.sig"
 fi
 popd > /dev/null
 

--- a/build/install.sh
+++ b/build/install.sh
@@ -67,10 +67,10 @@ if [[ $cmd =~ ^-c ]]; then
 fi
 
 show "Package verification"
-gpg --verbose --verify "$DEB_TGT"/raspiBackup.deb.sig "$DEB_TGT"/raspiBackup.deb
+gpg --verbose --verify "$DEB_TGT"/raspibackup.deb.sig "$DEB_TGT"/raspibackup.deb
 
 show "Install package and all dependencies"
-sudo apt-get install --allow-downgrades -y "$DEB_TGT"/raspiBackup.deb
+sudo apt-get install --allow-downgrades -y "$DEB_TGT"/raspibackup.deb
 
 show "Show installation result"
 apt-cache policy raspibackup

--- a/build/package/DEBIAN/conffiles
+++ b/build/package/DEBIAN/conffiles
@@ -1,2 +1,2 @@
-/usr/local/etc/raspibackup/raspiBackup_de.conf
-/usr/local/etc/raspibackup/raspiBackup_en.conf
+${DIR_ETC}/${PACKAGE_NAME}/raspiBackup_de.conf
+${DIR_ETC}/${PACKAGE_NAME}/raspiBackup_en.conf

--- a/build/package/DEBIAN/conffiles
+++ b/build/package/DEBIAN/conffiles
@@ -1,2 +1,2 @@
-/etc/raspiBackup/raspiBackup_de.conf
-/etc/raspiBackup/raspiBackup_en.conf
+/usr/local/etc/raspibackup/raspiBackup_de.conf
+/usr/local/etc/raspibackup/raspiBackup_en.conf

--- a/build/package/DEBIAN/control
+++ b/build/package/DEBIAN/control
@@ -1,4 +1,4 @@
-Package: raspibackup
+Package: ${PACKAGE_NAME}
 Version: $VERSION
 Section: utils
 Priority: optional

--- a/build/package/DEBIAN/postinst
+++ b/build/package/DEBIAN/postinst
@@ -3,35 +3,34 @@
 set -euo pipefail
 
 # save existing config
-if [[ -f /usr/local/etc/raspibackup/raspiBackup.conf ]]; then
+if [[ -f ${DIR_ETC}/${PACKAGE_NAME}/raspiBackup.conf ]]; then
 	echo "Saving existing config file ..."
-	cp -a /usr/local/etc/raspibackup/raspiBackup.conf /usr/local/etc/raspibackup/raspiBackup.conf~ || true
+	cp -a "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup.conf "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup.conf~ || true
 fi
 
 
 # use German config file, English is default
 lang="${LANG:0:2}"
 if [[ "$lang" == "de" ]]; then
-	if [[ -f /usr/local/etc/raspibackup/raspiBackup_de.conf ]]; then
+	if [[ -f ${DIR_ETC}/${PACKAGE_NAME}/raspiBackup_de.conf ]]; then
 		echo "Installing de ..."
-		mv /usr/local/etc/raspibackup/raspiBackup_de.conf /usr/local/etc/raspibackup/raspiBackup.conf || true
-		rm /usr/local/etc/raspibackup/raspiBackup_en.conf || true
+		mv "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup_de.conf "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup.conf || true
+		rm "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup_en.conf || true
 	else
 		echo "??? Installation raspiBackup.conf (de) failed"
 	fi
 else
-	if [[ -f /usr/local/etc/raspibackup/raspiBackup_de.conf ]]; then
+	if [[ -f ${DIR_ETC}/${PACKAGE_NAME}/raspiBackup_de.conf ]]; then
 		echo "Installing en ..."
-		mv /usr/local/etc/raspibackup/raspiBackup_en.conf /usr/local/etc/raspibackup/raspiBackup.conf || true
-		rm /usr/local/etc/raspibackup/raspiBackup_de.conf || true
+		mv "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup_en.conf "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup.conf || true
+		rm "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup_de.conf || true
 	else
 		echo "??? Installation raspiBackup.conf (en) failed"
 	fi
 fi
 
 # config may contain sensitive information like pwds, keys et al
-chmod 600 /usr/local/etc/raspibackup/raspiBackup.conf || true
+chmod 600 "${DIR_ETC}/${PACKAGE_NAME}"/raspiBackup.conf || true
 
 echo "DONE: postinst"
 # @TBD - merge new config file with old file
-

--- a/build/package/DEBIAN/postinst
+++ b/build/package/DEBIAN/postinst
@@ -3,34 +3,34 @@
 set -euo pipefail
 
 # save existing config
-if [[ -f /etc/raspiBackup/raspiBackup.conf ]]; then
+if [[ -f /usr/local/etc/raspibackup/raspiBackup.conf ]]; then
 	echo "Saving existing config file ..."
-	cp -a /etc/raspiBackup/raspiBackup.conf /etc/raspiBackup/raspiBackup.conf~ || true
+	cp -a /usr/local/etc/raspibackup/raspiBackup.conf /usr/local/etc/raspibackup/raspiBackup.conf~ || true
 fi
 
 
 # use German config file, English is default
 lang="${LANG:0:2}"
 if [[ "$lang" == "de" ]]; then
-	if [[ -f /etc/raspiBackup/raspiBackup_de.conf ]]; then
+	if [[ -f /usr/local/etc/raspibackup/raspiBackup_de.conf ]]; then
 		echo "Installing de ..."
-		mv /etc/raspiBackup/raspiBackup_de.conf /etc/raspiBackup/raspiBackup.conf || true
-		rm /etc/raspiBackup/raspiBackup_en.conf || true
+		mv /usr/local/etc/raspibackup/raspiBackup_de.conf /usr/local/etc/raspibackup/raspiBackup.conf || true
+		rm /usr/local/etc/raspibackup/raspiBackup_en.conf || true
 	else
 		echo "??? Installation raspiBackup.conf (de) failed"
 	fi
 else
-	if [[ -f /etc/raspiBackup/raspiBackup_de.conf ]]; then
+	if [[ -f /usr/local/etc/raspibackup/raspiBackup_de.conf ]]; then
 		echo "Installing en ..."
-		mv /etc/raspiBackup/raspiBackup_en.conf /etc/raspiBackup/raspiBackup.conf || true
-		rm /etc/raspiBackup/raspiBackup_de.conf || true
+		mv /usr/local/etc/raspibackup/raspiBackup_en.conf /usr/local/etc/raspibackup/raspiBackup.conf || true
+		rm /usr/local/etc/raspibackup/raspiBackup_de.conf || true
 	else
 		echo "??? Installation raspiBackup.conf (en) failed"
 	fi
 fi
 
 # config may contain sensitive information like pwds, keys et al
-chmod 600 /etc/raspiBackup/raspiBackup.conf || true
+chmod 600 /usr/local/etc/raspibackup/raspiBackup.conf || true
 
 echo "DONE: postinst"
 # @TBD - merge new config file with old file

--- a/build/package/DEBIAN/postrm
+++ b/build/package/DEBIAN/postrm
@@ -2,10 +2,10 @@
 
 set -euo pipefail
 
-echo "Cleaning up temp files"
-if [[ -d /etc/raspiBackup ]]; then
-	rm -f /etc/raspiBackup/* || true
-	rmdir /etc/raspiBackup || true
+echo "Cleaning up config files"
+if [[ -d /usr/local/etc/raspibackup ]]; then
+	rm -f /usr/local/etc/raspibackup/* || true
+	rmdir /usr/local/etc/raspibackup || true
 fi
 
 echo "DONE: postrm"

--- a/build/package/DEBIAN/postrm
+++ b/build/package/DEBIAN/postrm
@@ -3,9 +3,9 @@
 set -euo pipefail
 
 echo "Cleaning up config files"
-if [[ -d /usr/local/etc/raspibackup ]]; then
-	rm -f /usr/local/etc/raspibackup/* || true
-	rmdir /usr/local/etc/raspibackup || true
+if [[ -d "${DIR_ETC}/${PACKAGE_NAME}" ]]; then
+	rm -f "${DIR_ETC}/${PACKAGE_NAME}"/* || true
+	rmdir "${DIR_ETC}/${PACKAGE_NAME}" || true
 fi
 
 echo "DONE: postrm"

--- a/installation/raspiBackup.service
+++ b/installation/raspiBackup.service
@@ -3,6 +3,6 @@ Description=Creation of a Raspberry backup with raspiBackup
 
 [Service]
 Type=simple
-ExecStart=/usr/share/raspiBackup/raspiBackup.sh
+ExecStart=/usr/local/bin/raspiBackup.sh
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
According to Linux FHS I moved the files to /usr/local/... 
My feeling is it's a better place, **but I'm not sure**. Lintian is complaining... But it's not a real Debian package though...
To make these changes easier I put all pathes and the package name itself into variables.

Lintian is silenced now regarding several message tags. At least as demonstration... ;-)  But maybe it's better to let it fully complain?

Note: I ignored the open issues for now, sorry. Too many branches get easily mixed up in my head otherwise.