### PR TITLE
Remove 'append' parameter from raspiBackup_mail.sh

### DIFF
--- a/extensions/raspiBackup_mail.sh
+++ b/extensions/raspiBackup_mail.sh
@@ -31,7 +31,8 @@
 GIT_DATE="$Date$"
 GIT_COMMIT="$Sha1$"
 
-# Parameters received by script: "$EMAIL" "$subject" "$content" "$EMAIL_PARMS" "$append"
+# the fifth parameter "apend" was removed from version 0.7.2 to 0.7.3
+# Parameters received by script: "$EMAIL" "$subject" "$content" "$EMAIL_PARMS"
 
 MYSELF=${0##*/}
 MYNAME=${MYSELF%.*}
@@ -40,8 +41,8 @@ DEBUG=0			# 0/1 toggle for debugging
 
 # guard for invalid invocation
 
-if [[ $# != 5 ]]; then
-	echo "Missing parameters for $MYNAME. Expected: 5. Received $#"
+if [[ $# != 4 ]]; then
+	echo "Missing parameters for $MYNAME. Expected: 4. Received $#"
 	exit 127
 fi
 
@@ -51,7 +52,7 @@ email="$1"		# target email address
 subject="$2"	# email subject
 content="$3"	# email contents
 parms="$4"		# addtl email parms passed with -E
-append="$5"		# file to append
+# append="$5"		# file to append
 
 # print received parameters for debugging purposes
 
@@ -60,15 +61,16 @@ if (( $DEBUG )); then
 	echo "subject: ->$subject<-"
 	echo "content: ->$content<-"
 	echo "parms: ->$parms<-"
-	echo "append: ->$append<-"
+# 	echo "append: ->$append<-"
 fi
 
-[[ -n $append ]] && append="-a $append"
+# [[ -n $append ]] && append="-a $append"
 
 (( $DEBUG )) && set -x
 
 # sample to send mail with mailx client
 
-mailx $parms -s "$subject" $append "$email"	<<< "$content"
+# mailx $parms -s "$subject" $append "$email"	<<< "$content"
+mailx $parms -s "$subject" "$email"	<<< "$content"
 
 exit 0


### PR DESCRIPTION
Updated the script to remove the fifth parameter 'append' and adjusted the parameter count check accordingly.

The reason for this change is that the fifth parameter “append” was removed from the 'raspiBackup_mail.sh' call in 'raspiBackup.sh' starting with version 0.7.3.

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**

*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

Please provide enough information so that others can review your pull request:

Explain the **details** for making this change. What existing problem does the pull request solve?

**Explain how the PR was tested. If possible include a test script in your PR**

Demonstrate the code is solid. Example: The exact commands you ran and their output, screenshots / videos if the pull request changes UI.
